### PR TITLE
tests: include limits lib to fix build on debian

### DIFF
--- a/test/unit_tests.cpp
+++ b/test/unit_tests.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <assert.h>
+#include <limits.h>
 
 static inline void ok_or_panic(int err) {
     if (err)


### PR DESCRIPTION
This include of limits.h was needed to successfully run `make` on Debian Jessie.