### PR TITLE
[RDY] Compile in C++ mode using the <atomic> header

### DIFF
--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -183,6 +183,8 @@ enum SoundIoChannelId {
     SoundIoChannelIdAux13,
     SoundIoChannelIdAux14,
     SoundIoChannelIdAux15,
+
+    SoundIoChannelIdMax
 };
 
 /// Built-in channel layouts for convenience.
@@ -213,6 +215,8 @@ enum SoundIoChannelLayoutId {
     SoundIoChannelLayoutId7Point1Wide,
     SoundIoChannelLayoutId7Point1WideBack,
     SoundIoChannelLayoutIdOctagonal,
+
+    SoundIoChannelLayoutIdMax
 };
 
 enum SoundIoBackend {

--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -19,7 +19,7 @@
 #endif
 
 #if defined(SOUNDIO_STATIC_LIBRARY)
-# define SOUNDIO_EXPORT
+# define SOUNDIO_EXPORT SOUNDIO_EXTERN_C
 #else
 # if defined(_WIN32)
 #  if defined(SOUNDIO_BUILDING_LIBRARY)
@@ -183,8 +183,6 @@ enum SoundIoChannelId {
     SoundIoChannelIdAux13,
     SoundIoChannelIdAux14,
     SoundIoChannelIdAux15,
-
-    SoundIoChannelIdMax
 };
 
 /// Built-in channel layouts for convenience.
@@ -215,8 +213,6 @@ enum SoundIoChannelLayoutId {
     SoundIoChannelLayoutId7Point1Wide,
     SoundIoChannelLayoutId7Point1WideBack,
     SoundIoChannelLayoutIdOctagonal,
-
-    SoundIoChannelLayoutIdMax
 };
 
 enum SoundIoBackend {

--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -18,14 +18,18 @@
 #define SOUNDIO_EXTERN_C
 #endif
 
-#if defined(_WIN32)
-#if defined(SOUNDIO_BUILDING_LIBRARY)
-#define SOUNDIO_EXPORT SOUNDIO_EXTERN_C __declspec(dllexport)
+#if defined(SOUNDIO_STATIC_LIBRARY)
+# define SOUNDIO_EXPORT
 #else
-#define SOUNDIO_EXPORT SOUNDIO_EXTERN_C __declspec(dllimport)
-#endif
-#else
-#define SOUNDIO_EXPORT SOUNDIO_EXTERN_C __attribute__((visibility ("default")))
+# if defined(_WIN32)
+#  if defined(SOUNDIO_BUILDING_LIBRARY)
+#   define SOUNDIO_EXPORT SOUNDIO_EXTERN_C __declspec(dllexport)
+#  else
+#   define SOUNDIO_EXPORT SOUNDIO_EXTERN_C __declspec(dllimport)
+#  endif
+# else
+#  define SOUNDIO_EXPORT SOUNDIO_EXTERN_C __attribute__((visibility ("default")))
+# endif
 #endif
 /// \endcond
 

--- a/src/alsa.h
+++ b/src/alsa.h
@@ -32,7 +32,7 @@ struct SoundIoAlsa {
     struct SoundIoOsCond *cond;
 
     struct SoundIoOsThread *thread;
-    atomic_flag abort_flag;
+    struct SoundIoAtomicFlag abort_flag;
     int notify_fd;
     int notify_wd;
     bool have_devices_flag;
@@ -60,11 +60,11 @@ struct SoundIoOutStreamAlsa {
     struct pollfd *poll_fds;
     int poll_exit_pipe_fd[2];
     struct SoundIoOsThread *thread;
-    atomic_flag thread_exit_flag;
+    struct SoundIoAtomicFlag thread_exit_flag;
     snd_pcm_uframes_t period_size;
     int write_frame_count;
     bool is_paused;
-    atomic_flag clear_buffer_flag;
+    struct SoundIoAtomicFlag clear_buffer_flag;
     struct SoundIoChannelArea areas[SOUNDIO_MAX_CHANNELS];
 };
 
@@ -79,7 +79,7 @@ struct SoundIoInStreamAlsa {
     int poll_fd_count;
     struct pollfd *poll_fds;
     struct SoundIoOsThread *thread;
-    atomic_flag thread_exit_flag;
+    struct SoundIoAtomicFlag thread_exit_flag;
     int period_size;
     int read_frame_count;
     bool is_paused;

--- a/src/atomics.h
+++ b/src/atomics.h
@@ -11,6 +11,29 @@
 // Simple wrappers around atomic values so that the compiler will catch it if
 // I accidentally use operators such as +, -, += on them.
 
+#ifdef __cplusplus
+
+#include <atomic>
+
+struct SoundIoAtomicLong {
+    std::atomic<long> x;
+};
+
+struct SoundIoAtomicInt {
+    std::atomic<int> x;
+};
+
+struct SoundIoAtomicBool {
+    std::atomic<bool> x;
+};
+
+#define SOUNDIO_ATOMIC_LOAD(a) (a.x.load())
+#define SOUNDIO_ATOMIC_FETCH_ADD(a, delta) (a.x.fetch_add(delta))
+#define SOUNDIO_ATOMIC_STORE(a, value) (a.x.store(value))
+#define SOUNDIO_ATOMIC_EXCHANGE(a, value) (a.x.exchange(value))
+
+#else
+
 #include <stdatomic.h>
 
 struct SoundIoAtomicLong {
@@ -29,5 +52,7 @@ struct SoundIoAtomicBool {
 #define SOUNDIO_ATOMIC_FETCH_ADD(a, delta) atomic_fetch_add(&a.x, delta)
 #define SOUNDIO_ATOMIC_STORE(a, value) atomic_store(&a.x, value)
 #define SOUNDIO_ATOMIC_EXCHANGE(a, value) atomic_exchange(&a.x, value)
+
+#endif
 
 #endif

--- a/src/atomics.h
+++ b/src/atomics.h
@@ -27,10 +27,17 @@ struct SoundIoAtomicBool {
     std::atomic<bool> x;
 };
 
+struct SoundIoAtomicFlag {
+    std::atomic_flag x;
+};
+
 #define SOUNDIO_ATOMIC_LOAD(a) (a.x.load())
 #define SOUNDIO_ATOMIC_FETCH_ADD(a, delta) (a.x.fetch_add(delta))
 #define SOUNDIO_ATOMIC_STORE(a, value) (a.x.store(value))
 #define SOUNDIO_ATOMIC_EXCHANGE(a, value) (a.x.exchange(value))
+#define SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(a) (a.x.test_and_set())
+#define SOUNDIO_ATOMIC_FLAG_CLEAR(a) (a.x.clear())
+#define SOUNDIO_ATOMIC_FLAG_INIT {ATOMIC_FLAG_INIT}
 
 #else
 
@@ -48,10 +55,17 @@ struct SoundIoAtomicBool {
     atomic_bool x;
 };
 
+struct SoundIoAtomicFlag {
+    atomic_flag x;
+};
+
 #define SOUNDIO_ATOMIC_LOAD(a) atomic_load(&a.x)
 #define SOUNDIO_ATOMIC_FETCH_ADD(a, delta) atomic_fetch_add(&a.x, delta)
 #define SOUNDIO_ATOMIC_STORE(a, value) atomic_store(&a.x, value)
 #define SOUNDIO_ATOMIC_EXCHANGE(a, value) atomic_exchange(&a.x, value)
+#define SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(a) atomic_flag_test_and_set(&a.x)
+#define SOUNDIO_ATOMIC_FLAG_CLEAR(a) atomic_flag_clear(&a.x)
+#define SOUNDIO_ATOMIC_FLAG_INIT {ATOMIC_FLAG_INIT}
 
 #endif
 

--- a/src/channel_layout.c
+++ b/src/channel_layout.c
@@ -9,23 +9,25 @@
 
 #include <stdio.h>
 
-static struct SoundIoChannelLayout builtin_channel_layouts[] = {
-    [SoundIoChannelLayoutIdMono] = {
+static struct SoundIoChannelLayout *make_builtin_channel_layouts()
+{
+    static struct SoundIoChannelLayout layouts[SoundIoChannelLayoutIdMax];
+    layouts[SoundIoChannelLayoutIdMono] = {
         "Mono",
         1,
         {
             SoundIoChannelIdFrontCenter,
         },
-    },
-    [SoundIoChannelLayoutIdStereo] = {
+    };
+    layouts[SoundIoChannelLayoutIdStereo] = {
         "Stereo",
         2,
         {
             SoundIoChannelIdFrontLeft,
             SoundIoChannelIdFrontRight,
         },
-    },
-    [SoundIoChannelLayoutId2Point1] = {
+    };
+    layouts[SoundIoChannelLayoutId2Point1] = {
         "2.1",
         3,
         {
@@ -33,8 +35,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontRight,
             SoundIoChannelIdLfe,
         },
-    },
-    [SoundIoChannelLayoutId3Point0] = {
+    };
+    layouts[SoundIoChannelLayoutId3Point0] = {
         "3.0",
         3,
         {
@@ -42,8 +44,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontRight,
             SoundIoChannelIdFrontCenter,
         }
-    },
-    [SoundIoChannelLayoutId3Point0Back] = {
+    };
+    layouts[SoundIoChannelLayoutId3Point0Back] = {
         "3.0 (back)",
         3,
         {
@@ -51,8 +53,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontRight,
             SoundIoChannelIdBackCenter,
         }
-    },
-    [SoundIoChannelLayoutId3Point1] = {
+    };
+    layouts[SoundIoChannelLayoutId3Point1] = {
         "3.1",
         4,
         {
@@ -61,8 +63,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontCenter,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId4Point0] = {
+    };
+    layouts[SoundIoChannelLayoutId4Point0] = {
         "4.0",
         4,
         {
@@ -71,8 +73,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontCenter,
             SoundIoChannelIdBackCenter,
         }
-    },
-    [SoundIoChannelLayoutIdQuad] = {
+    };
+    layouts[SoundIoChannelLayoutIdQuad] = {
         "Quad",
         4,
         {
@@ -81,8 +83,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackLeft,
             SoundIoChannelIdBackRight,
         },
-    },
-    [SoundIoChannelLayoutIdQuadSide] = {
+    };
+    layouts[SoundIoChannelLayoutIdQuadSide] = {
         "Quad (side)",
         4,
         {
@@ -91,8 +93,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdSideLeft,
             SoundIoChannelIdSideRight,
         }
-    },
-    [SoundIoChannelLayoutId4Point1] = {
+    };
+    layouts[SoundIoChannelLayoutId4Point1] = {
         "4.1",
         5,
         {
@@ -102,8 +104,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackCenter,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId5Point0Back] = {
+    };
+    layouts[SoundIoChannelLayoutId5Point0Back] = {
         "5.0 (back)",
         5,
         {
@@ -113,8 +115,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackLeft,
             SoundIoChannelIdBackRight,
         }
-    },
-    [SoundIoChannelLayoutId5Point0Side] = {
+    };
+    layouts[SoundIoChannelLayoutId5Point0Side] = {
         "5.0 (side)",
         5,
         {
@@ -124,8 +126,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdSideLeft,
             SoundIoChannelIdSideRight,
         }
-    },
-    [SoundIoChannelLayoutId5Point1] = {
+    };
+    layouts[SoundIoChannelLayoutId5Point1] = {
         "5.1",
         6,
         {
@@ -136,8 +138,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdSideRight,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId5Point1Back] = {
+    };
+    layouts[SoundIoChannelLayoutId5Point1Back] = {
         "5.1 (back)",
         6,
         {
@@ -148,8 +150,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackRight,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId6Point0Side] = {
+    };
+    layouts[SoundIoChannelLayoutId6Point0Side] = {
         "6.0 (side)",
         6,
         {
@@ -160,8 +162,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdSideRight,
             SoundIoChannelIdBackCenter,
         }
-    },
-    [SoundIoChannelLayoutId6Point0Front] = {
+    };
+    layouts[SoundIoChannelLayoutId6Point0Front] = {
         "6.0 (front)",
         6,
         {
@@ -172,8 +174,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontLeftCenter,
             SoundIoChannelIdFrontRightCenter,
         }
-    },
-    [SoundIoChannelLayoutIdHexagonal] = {
+    };
+    layouts[SoundIoChannelLayoutIdHexagonal] = {
         "Hexagonal",
         6,
         {
@@ -184,8 +186,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackRight,
             SoundIoChannelIdBackCenter,
         }
-    },
-    [SoundIoChannelLayoutId6Point1] = {
+    };
+    layouts[SoundIoChannelLayoutId6Point1] = {
         "6.1",
         7,
         {
@@ -197,8 +199,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackCenter,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId6Point1Back] = {
+    };
+    layouts[SoundIoChannelLayoutId6Point1Back] = {
         "6.1 (back)",
         7,
         {
@@ -210,8 +212,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackCenter,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId6Point1Front] = {
+    };
+    layouts[SoundIoChannelLayoutId6Point1Front] = {
         "6.1 (front)",
         7,
         {
@@ -223,8 +225,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontRightCenter,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId7Point0] = {
+    };
+    layouts[SoundIoChannelLayoutId7Point0] = {
         "7.0",
         7,
         {
@@ -236,8 +238,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackLeft,
             SoundIoChannelIdBackRight,
         }
-    },
-    [SoundIoChannelLayoutId7Point0Front] = {
+    };
+    layouts[SoundIoChannelLayoutId7Point0Front] = {
         "7.0 (front)",
         7,
         {
@@ -249,8 +251,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontLeftCenter,
             SoundIoChannelIdFrontRightCenter,
         }
-    },
-    [SoundIoChannelLayoutId7Point1] = {
+    };
+    layouts[SoundIoChannelLayoutId7Point1] = {
         "7.1",
         8,
         {
@@ -263,8 +265,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackRight,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId7Point1Wide] = {
+    };
+    layouts[SoundIoChannelLayoutId7Point1Wide] = {
         "7.1 (wide)",
         8,
         {
@@ -277,8 +279,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontRightCenter,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutId7Point1WideBack] = {
+    };
+    layouts[SoundIoChannelLayoutId7Point1WideBack] = {
         "7.1 (wide) (back)",
         8,
         {
@@ -291,8 +293,8 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdFrontRightCenter,
             SoundIoChannelIdLfe,
         }
-    },
-    [SoundIoChannelLayoutIdOctagonal] = {
+    };
+    layouts[SoundIoChannelLayoutIdOctagonal] = {
         "Octagonal",
         8,
         {
@@ -305,357 +307,226 @@ static struct SoundIoChannelLayout builtin_channel_layouts[] = {
             SoundIoChannelIdBackRight,
             SoundIoChannelIdBackCenter,
         }
-    },
+    };
+    return &layouts[0];
 };
+static struct SoundIoChannelLayout *builtin_channel_layouts = make_builtin_channel_layouts();
 
 #define CHANNEL_NAME_ALIAS_COUNT 3
-static const char *channel_names[][CHANNEL_NAME_ALIAS_COUNT] = {
-    [SoundIoChannelIdInvalid] = {
-        "(Invalid Channel)",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdFrontLeft] = {
-        "Front Left",
-        "FL",
-        "front-left",
-    },
-    [SoundIoChannelIdFrontRight] = {
-        "Front Right",
-        "FR",
-        "front-right",
-    },
-    [SoundIoChannelIdFrontCenter] = {
-        "Front Center",
-        "FC",
-        "front-center",
-    },
-    [SoundIoChannelIdLfe] = {
-        "LFE",
-        "LFE",
-        "lfe",
-    },
-    [SoundIoChannelIdBackLeft] = {
-        "Back Left",
-        "BL",
-        "rear-left",
-    },
-    [SoundIoChannelIdBackRight] = {
-        "Back Right",
-        "BR",
-        "rear-right",
-    },
-    [SoundIoChannelIdFrontLeftCenter] = {
-        "Front Left Center",
-        "FLC",
-        "front-left-of-center",
-    },
-    [SoundIoChannelIdFrontRightCenter] = {
-        "Front Right Center",
-        "FRC",
-        "front-right-of-center",
-    },
-    [SoundIoChannelIdBackCenter] = {
-        "Back Center",
-        "BC",
-        "rear-center",
-    },
-    [SoundIoChannelIdSideLeft] = {
-        "Side Left",
-        "SL",
-        "side-left",
-    },
-    [SoundIoChannelIdSideRight] = {
-        "Side Right",
-        "SR",
-        "side-right",
-    },
-    [SoundIoChannelIdTopCenter] = {
-        "Top Center",
-        "TC",
-        "top-center",
-    },
-    [SoundIoChannelIdTopFrontLeft] = {
-        "Top Front Left",
-        "TFL",
-        "top-front-left",
-    },
-    [SoundIoChannelIdTopFrontCenter] = {
-        "Top Front Center",
-        "TFC",
-        "top-front-center",
-    },
-    [SoundIoChannelIdTopFrontRight] = {
-        "Top Front Right",
-        "TFR",
-        "top-front-right",
-    },
-    [SoundIoChannelIdTopBackLeft] = {
-        "Top Back Left",
-        "TBL",
-        "top-rear-left",
-    },
-    [SoundIoChannelIdTopBackCenter] = {
-        "Top Back Center",
-        "TBC",
-        "top-rear-center",
-    },
-    [SoundIoChannelIdTopBackRight] = {
-        "Top Back Right",
-        "TBR",
-        "top-rear-right",
-    },
-    [SoundIoChannelIdBackLeftCenter] = {
-        "Back Left Center",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdBackRightCenter] = {
-        "Back Right Center",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdFrontLeftWide] = {
-        "Front Left Wide",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdFrontRightWide] = {
-        "Front Right Wide",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdFrontLeftHigh] = {
-        "Front Left High",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdFrontCenterHigh] = {
-        "Front Center High",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdFrontRightHigh] = {
-        "Front Right High",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdTopFrontLeftCenter] = {
-        "Top Front Left Center",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdTopFrontRightCenter] = {
-        "Top Front Right Center",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdTopSideLeft] = {
-        "Top Side Left",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdTopSideRight] = {
-        "Top Side Right",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdLeftLfe] = {
-        "Left LFE",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdRightLfe] = {
-        "Right LFE",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdLfe2] = {
-        "LFE 2",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdBottomCenter] = {
-        "Bottom Center",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdBottomLeftCenter] = {
-        "Bottom Left Center",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdBottomRightCenter] = {
-        "Bottom Right Center",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdMsMid] = {
-        "Mid/Side Mid",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdMsSide] = {
-        "Mid/Side Side",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAmbisonicW] = {
-        "Ambisonic W",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAmbisonicX] = {
-        "Ambisonic X",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAmbisonicY] = {
-        "Ambisonic Y",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAmbisonicZ] = {
-        "Ambisonic Z",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdXyX] = {
-        "X-Y X",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdXyY] = {
-        "X-Y Y",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdHeadphonesLeft] = {
-        "Headphones Left",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdHeadphonesRight] = {
-        "Headphones Right",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdClickTrack] = {
-        "Click Track",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdForeignLanguage] = {
-        "Foreign Language",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdHearingImpaired] = {
-        "Hearing Impaired",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdNarration] = {
-        "Narration",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdHaptic] = {
-        "Haptic",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdDialogCentricMix] = {
-        "Dialog Centric Mix",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux] = {
-        "Aux",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux0] = {
-        "Aux 0",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux1] = {
-        "Aux 1",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux2] = {
-        "Aux 2",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux3] = {
-        "Aux 3",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux4] = {
-        "Aux 4",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux5] = {
-        "Aux 5",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux6] = {
-        "Aux 6",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux7] = {
-        "Aux 7",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux8] = {
-        "Aux 8",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux9] = {
-        "Aux 9",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux10] = {
-        "Aux 10",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux11] = {
-        "Aux 11",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux12] = {
-        "Aux 12",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux13] = {
-        "Aux 13",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux14] = {
-        "Aux 14",
-        NULL,
-        NULL,
-    },
-    [SoundIoChannelIdAux15] = {
-        "Aux 15",
-        NULL,
-        NULL,
-    },
+typedef const char *channel_names_t[CHANNEL_NAME_ALIAS_COUNT];
+static channel_names_t *make_channel_names()
+{
+    static channel_names_t names[SoundIoChannelIdMax];
+    names[SoundIoChannelIdInvalid][0] = "(Invalid Channel)";
+    names[SoundIoChannelIdInvalid][1] = NULL;
+    names[SoundIoChannelIdInvalid][2] = NULL;
+    names[SoundIoChannelIdFrontLeft][0] = "Front Left";
+    names[SoundIoChannelIdFrontLeft][1] = "FL";
+    names[SoundIoChannelIdFrontLeft][2] = "front-left";
+    names[SoundIoChannelIdFrontRight][0] = "Front Right";
+    names[SoundIoChannelIdFrontRight][1] = "FR";
+    names[SoundIoChannelIdFrontRight][2] = "front-right";
+    names[SoundIoChannelIdFrontCenter][0] = "Front Center";
+    names[SoundIoChannelIdFrontCenter][1] = "FC";
+    names[SoundIoChannelIdFrontCenter][2] = "front-center";
+    names[SoundIoChannelIdLfe][0] = "LFE";
+    names[SoundIoChannelIdLfe][1] = "LFE";
+    names[SoundIoChannelIdLfe][2] = "lfe";
+    names[SoundIoChannelIdBackLeft][0] = "Back Left";
+    names[SoundIoChannelIdBackLeft][1] = "BL";
+    names[SoundIoChannelIdBackLeft][2] = "rear-left";
+    names[SoundIoChannelIdBackRight][0] = "Back Right";
+    names[SoundIoChannelIdBackRight][1] = "BR";
+    names[SoundIoChannelIdBackRight][2] = "rear-right";
+    names[SoundIoChannelIdFrontLeftCenter][0] = "Front Left Center";
+    names[SoundIoChannelIdFrontLeftCenter][1] = "FLC";
+    names[SoundIoChannelIdFrontLeftCenter][2] = "front-left-of-center";
+    names[SoundIoChannelIdFrontRightCenter][0] = "Front Right Center";
+    names[SoundIoChannelIdFrontRightCenter][1] = "FRC";
+    names[SoundIoChannelIdFrontRightCenter][2] = "front-right-of-center";
+    names[SoundIoChannelIdBackCenter][0] = "Back Center";
+    names[SoundIoChannelIdBackCenter][1] = "BC";
+    names[SoundIoChannelIdBackCenter][2] = "rear-center";
+    names[SoundIoChannelIdSideLeft][0] = "Side Left";
+    names[SoundIoChannelIdSideLeft][1] = "SL";
+    names[SoundIoChannelIdSideLeft][2] = "side-left";
+    names[SoundIoChannelIdSideRight][0] = "Side Right";
+    names[SoundIoChannelIdSideRight][1] = "SR";
+    names[SoundIoChannelIdSideRight][2] = "side-right";
+    names[SoundIoChannelIdTopCenter][0] = "Top Center";
+    names[SoundIoChannelIdTopCenter][1] = "TC";
+    names[SoundIoChannelIdTopCenter][2] = "top-center";
+    names[SoundIoChannelIdTopFrontLeft][0] = "Top Front Left";
+    names[SoundIoChannelIdTopFrontLeft][1] = "TFL";
+    names[SoundIoChannelIdTopFrontLeft][2] = "top-front-left";
+    names[SoundIoChannelIdTopFrontCenter][0] = "Top Front Center";
+    names[SoundIoChannelIdTopFrontCenter][1] = "TFC";
+    names[SoundIoChannelIdTopFrontCenter][2] = "top-front-center";
+    names[SoundIoChannelIdTopFrontRight][0] = "Top Front Right";
+    names[SoundIoChannelIdTopFrontRight][1] = "TFR";
+    names[SoundIoChannelIdTopFrontRight][2] = "top-front-right";
+    names[SoundIoChannelIdTopBackLeft][0] = "Top Back Left";
+    names[SoundIoChannelIdTopBackLeft][1] = "TBL";
+    names[SoundIoChannelIdTopBackLeft][2] = "top-rear-left";
+    names[SoundIoChannelIdTopBackCenter][0] = "Top Back Center";
+    names[SoundIoChannelIdTopBackCenter][1] = "TBC";
+    names[SoundIoChannelIdTopBackCenter][2] = "top-rear-center";
+    names[SoundIoChannelIdTopBackRight][0] = "Top Back Right";
+    names[SoundIoChannelIdTopBackRight][1] = "TBR";
+    names[SoundIoChannelIdTopBackRight][2] = "top-rear-right";
+    names[SoundIoChannelIdBackLeftCenter][0] = "Back Left Center";
+    names[SoundIoChannelIdBackLeftCenter][1] = NULL;
+    names[SoundIoChannelIdBackLeftCenter][2] = NULL;
+    names[SoundIoChannelIdBackRightCenter][0] = "Back Right Center";
+    names[SoundIoChannelIdBackRightCenter][1] = NULL;
+    names[SoundIoChannelIdBackRightCenter][2] = NULL;
+    names[SoundIoChannelIdFrontLeftWide][0] = "Front Left Wide";
+    names[SoundIoChannelIdFrontLeftWide][1] = NULL;
+    names[SoundIoChannelIdFrontLeftWide][2] = NULL;
+    names[SoundIoChannelIdFrontRightWide][0] = "Front Right Wide";
+    names[SoundIoChannelIdFrontRightWide][1] = NULL;
+    names[SoundIoChannelIdFrontRightWide][2] = NULL;
+    names[SoundIoChannelIdFrontLeftHigh][0] = "Front Left High";
+    names[SoundIoChannelIdFrontLeftHigh][1] = NULL;
+    names[SoundIoChannelIdFrontLeftHigh][2] = NULL;
+    names[SoundIoChannelIdFrontCenterHigh][0] = "Front Center High";
+    names[SoundIoChannelIdFrontCenterHigh][1] = NULL;
+    names[SoundIoChannelIdFrontCenterHigh][2] = NULL;
+    names[SoundIoChannelIdFrontRightHigh][0] = "Front Right High";
+    names[SoundIoChannelIdFrontRightHigh][1] = NULL;
+    names[SoundIoChannelIdFrontRightHigh][2] = NULL;
+    names[SoundIoChannelIdTopFrontLeftCenter][0] = "Top Front Left Center";
+    names[SoundIoChannelIdTopFrontLeftCenter][1] = NULL;
+    names[SoundIoChannelIdTopFrontLeftCenter][2] = NULL;
+    names[SoundIoChannelIdTopFrontRightCenter][0] = "Top Front Right Center";
+    names[SoundIoChannelIdTopFrontRightCenter][1] = NULL;
+    names[SoundIoChannelIdTopFrontRightCenter][2] = NULL;
+    names[SoundIoChannelIdTopSideLeft][0] = "Top Side Left";
+    names[SoundIoChannelIdTopSideLeft][1] = NULL;
+    names[SoundIoChannelIdTopSideLeft][2] = NULL;
+    names[SoundIoChannelIdTopSideRight][0] = "Top Side Right";
+    names[SoundIoChannelIdTopSideRight][1] = NULL;
+    names[SoundIoChannelIdTopSideRight][2] = NULL;
+    names[SoundIoChannelIdLeftLfe][0] = "Left LFE";
+    names[SoundIoChannelIdLeftLfe][1] = NULL;
+    names[SoundIoChannelIdLeftLfe][2] = NULL;
+    names[SoundIoChannelIdRightLfe][0] = "Right LFE";
+    names[SoundIoChannelIdRightLfe][1] = NULL;
+    names[SoundIoChannelIdRightLfe][2] = NULL;
+    names[SoundIoChannelIdLfe2][0] = "LFE 2";
+    names[SoundIoChannelIdLfe2][1] = NULL;
+    names[SoundIoChannelIdLfe2][2] = NULL;
+    names[SoundIoChannelIdBottomCenter][0] = "Bottom Center";
+    names[SoundIoChannelIdBottomCenter][1] = NULL;
+    names[SoundIoChannelIdBottomCenter][2] = NULL;
+    names[SoundIoChannelIdBottomLeftCenter][0] = "Bottom Left Center";
+    names[SoundIoChannelIdBottomLeftCenter][1] = NULL;
+    names[SoundIoChannelIdBottomLeftCenter][2] = NULL;
+    names[SoundIoChannelIdBottomRightCenter][0] = "Bottom Right Center";
+    names[SoundIoChannelIdBottomRightCenter][1] = NULL;
+    names[SoundIoChannelIdBottomRightCenter][2] = NULL;
+    names[SoundIoChannelIdMsMid][0] = "Mid/Side Mid";
+    names[SoundIoChannelIdMsMid][1] = NULL;
+    names[SoundIoChannelIdMsMid][2] = NULL;
+    names[SoundIoChannelIdMsSide][0] = "Mid/Side Side";
+    names[SoundIoChannelIdMsSide][1] = NULL;
+    names[SoundIoChannelIdMsSide][2] = NULL;
+    names[SoundIoChannelIdAmbisonicW][0] = "Ambisonic W";
+    names[SoundIoChannelIdAmbisonicW][1] = NULL;
+    names[SoundIoChannelIdAmbisonicW][2] = NULL;
+    names[SoundIoChannelIdAmbisonicX][0] = "Ambisonic X";
+    names[SoundIoChannelIdAmbisonicX][1] = NULL;
+    names[SoundIoChannelIdAmbisonicX][2] = NULL;
+    names[SoundIoChannelIdAmbisonicY][0] = "Ambisonic Y";
+    names[SoundIoChannelIdAmbisonicY][1] = NULL;
+    names[SoundIoChannelIdAmbisonicY][2] = NULL;
+    names[SoundIoChannelIdAmbisonicZ][0] = "Ambisonic Z";
+    names[SoundIoChannelIdAmbisonicZ][1] = NULL;
+    names[SoundIoChannelIdAmbisonicZ][2] = NULL;
+    names[SoundIoChannelIdXyX][0] = "X-Y X";
+    names[SoundIoChannelIdXyX][1] = NULL;
+    names[SoundIoChannelIdXyX][2] = NULL;
+    names[SoundIoChannelIdXyY][0] = "X-Y Y";
+    names[SoundIoChannelIdXyY][1] = NULL;
+    names[SoundIoChannelIdXyY][2] = NULL;
+    names[SoundIoChannelIdHeadphonesLeft][0] = "Headphones Left";
+    names[SoundIoChannelIdHeadphonesLeft][1] = NULL;
+    names[SoundIoChannelIdHeadphonesLeft][2] = NULL;
+    names[SoundIoChannelIdHeadphonesRight][0] = "Headphones Right";
+    names[SoundIoChannelIdHeadphonesRight][1] = NULL;
+    names[SoundIoChannelIdHeadphonesRight][2] = NULL;
+    names[SoundIoChannelIdClickTrack][0] = "Click Track";
+    names[SoundIoChannelIdClickTrack][1] = NULL;
+    names[SoundIoChannelIdClickTrack][2] = NULL;
+    names[SoundIoChannelIdForeignLanguage][0] = "Foreign Language";
+    names[SoundIoChannelIdForeignLanguage][1] = NULL;
+    names[SoundIoChannelIdForeignLanguage][2] = NULL;
+    names[SoundIoChannelIdHearingImpaired][0] = "Hearing Impaired";
+    names[SoundIoChannelIdHearingImpaired][1] = NULL;
+    names[SoundIoChannelIdHearingImpaired][2] = NULL;
+    names[SoundIoChannelIdNarration][0] = "Narration";
+    names[SoundIoChannelIdNarration][1] = NULL;
+    names[SoundIoChannelIdNarration][2] = NULL;
+    names[SoundIoChannelIdHaptic][0] = "Haptic";
+    names[SoundIoChannelIdHaptic][1] = NULL;
+    names[SoundIoChannelIdHaptic][2] = NULL;
+    names[SoundIoChannelIdDialogCentricMix][0] = "Dialog Centric Mix";
+    names[SoundIoChannelIdDialogCentricMix][1] = NULL;
+    names[SoundIoChannelIdDialogCentricMix][2] = NULL;
+    names[SoundIoChannelIdAux][0] = "Aux";
+    names[SoundIoChannelIdAux][1] = NULL;
+    names[SoundIoChannelIdAux][2] = NULL;
+    names[SoundIoChannelIdAux0][0] = "Aux 0";
+    names[SoundIoChannelIdAux0][1] = NULL;
+    names[SoundIoChannelIdAux0][2] = NULL;
+    names[SoundIoChannelIdAux1][0] = "Aux 1";
+    names[SoundIoChannelIdAux1][1] = NULL;
+    names[SoundIoChannelIdAux1][2] = NULL;
+    names[SoundIoChannelIdAux2][0] = "Aux 2";
+    names[SoundIoChannelIdAux2][1] = NULL;
+    names[SoundIoChannelIdAux2][2] = NULL;
+    names[SoundIoChannelIdAux3][0] = "Aux 3";
+    names[SoundIoChannelIdAux3][1] = NULL;
+    names[SoundIoChannelIdAux3][2] = NULL;
+    names[SoundIoChannelIdAux4][0] = "Aux 4";
+    names[SoundIoChannelIdAux4][1] = NULL;
+    names[SoundIoChannelIdAux4][2] = NULL;
+    names[SoundIoChannelIdAux5][0] = "Aux 5";
+    names[SoundIoChannelIdAux5][1] = NULL;
+    names[SoundIoChannelIdAux5][2] = NULL;
+    names[SoundIoChannelIdAux6][0] = "Aux 6";
+    names[SoundIoChannelIdAux6][1] = NULL;
+    names[SoundIoChannelIdAux6][2] = NULL;
+    names[SoundIoChannelIdAux7][0] = "Aux 7";
+    names[SoundIoChannelIdAux7][1] = NULL;
+    names[SoundIoChannelIdAux7][2] = NULL;
+    names[SoundIoChannelIdAux8][0] = "Aux 8";
+    names[SoundIoChannelIdAux8][1] = NULL;
+    names[SoundIoChannelIdAux8][2] = NULL;
+    names[SoundIoChannelIdAux9][0] = "Aux 9";
+    names[SoundIoChannelIdAux9][1] = NULL;
+    names[SoundIoChannelIdAux9][2] = NULL;
+    names[SoundIoChannelIdAux10][0] = "Aux 10";
+    names[SoundIoChannelIdAux10][1] = NULL;
+    names[SoundIoChannelIdAux10][2] = NULL;
+    names[SoundIoChannelIdAux11][0] = "Aux 11";
+    names[SoundIoChannelIdAux11][1] = NULL;
+    names[SoundIoChannelIdAux11][2] = NULL;
+    names[SoundIoChannelIdAux12][0] = "Aux 12";
+    names[SoundIoChannelIdAux12][1] = NULL;
+    names[SoundIoChannelIdAux12][2] = NULL;
+    names[SoundIoChannelIdAux13][0] = "Aux 13";
+    names[SoundIoChannelIdAux13][1] = NULL;
+    names[SoundIoChannelIdAux13][2] = NULL;
+    names[SoundIoChannelIdAux14][0] = "Aux 14";
+    names[SoundIoChannelIdAux14][1] = NULL;
+    names[SoundIoChannelIdAux14][2] = NULL;
+    names[SoundIoChannelIdAux15][0] = "Aux 15";
+    names[SoundIoChannelIdAux15][1] = NULL;
+    names[SoundIoChannelIdAux15][2] = NULL;
+    return &names[0];
 };
+static channel_names_t *channel_names = make_channel_names();
 
 const char *soundio_get_channel_name(enum SoundIoChannelId id) {
     if (id >= ARRAY_LENGTH(channel_names))

--- a/src/channel_layout.c
+++ b/src/channel_layout.c
@@ -9,25 +9,23 @@
 
 #include <stdio.h>
 
-static struct SoundIoChannelLayout *make_builtin_channel_layouts()
-{
-    static struct SoundIoChannelLayout layouts[SoundIoChannelLayoutIdMax];
-    layouts[SoundIoChannelLayoutIdMono] = {
+static struct SoundIoChannelLayout builtin_channel_layouts[] = {
+    {
         "Mono",
         1,
         {
             SoundIoChannelIdFrontCenter,
         },
-    };
-    layouts[SoundIoChannelLayoutIdStereo] = {
+    },
+    {
         "Stereo",
         2,
         {
             SoundIoChannelIdFrontLeft,
             SoundIoChannelIdFrontRight,
         },
-    };
-    layouts[SoundIoChannelLayoutId2Point1] = {
+    },
+    {
         "2.1",
         3,
         {
@@ -35,8 +33,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontRight,
             SoundIoChannelIdLfe,
         },
-    };
-    layouts[SoundIoChannelLayoutId3Point0] = {
+    },
+    {
         "3.0",
         3,
         {
@@ -44,8 +42,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontRight,
             SoundIoChannelIdFrontCenter,
         }
-    };
-    layouts[SoundIoChannelLayoutId3Point0Back] = {
+    },
+    {
         "3.0 (back)",
         3,
         {
@@ -53,8 +51,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontRight,
             SoundIoChannelIdBackCenter,
         }
-    };
-    layouts[SoundIoChannelLayoutId3Point1] = {
+    },
+    {
         "3.1",
         4,
         {
@@ -63,8 +61,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontCenter,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId4Point0] = {
+    },
+    {
         "4.0",
         4,
         {
@@ -73,8 +71,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontCenter,
             SoundIoChannelIdBackCenter,
         }
-    };
-    layouts[SoundIoChannelLayoutIdQuad] = {
+    },
+    {
         "Quad",
         4,
         {
@@ -83,8 +81,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackLeft,
             SoundIoChannelIdBackRight,
         },
-    };
-    layouts[SoundIoChannelLayoutIdQuadSide] = {
+    },
+    {
         "Quad (side)",
         4,
         {
@@ -93,8 +91,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdSideLeft,
             SoundIoChannelIdSideRight,
         }
-    };
-    layouts[SoundIoChannelLayoutId4Point1] = {
+    },
+    {
         "4.1",
         5,
         {
@@ -104,8 +102,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackCenter,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId5Point0Back] = {
+    },
+    {
         "5.0 (back)",
         5,
         {
@@ -115,8 +113,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackLeft,
             SoundIoChannelIdBackRight,
         }
-    };
-    layouts[SoundIoChannelLayoutId5Point0Side] = {
+    },
+    {
         "5.0 (side)",
         5,
         {
@@ -126,8 +124,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdSideLeft,
             SoundIoChannelIdSideRight,
         }
-    };
-    layouts[SoundIoChannelLayoutId5Point1] = {
+    },
+    {
         "5.1",
         6,
         {
@@ -138,8 +136,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdSideRight,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId5Point1Back] = {
+    },
+    {
         "5.1 (back)",
         6,
         {
@@ -150,8 +148,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackRight,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId6Point0Side] = {
+    },
+    {
         "6.0 (side)",
         6,
         {
@@ -162,8 +160,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdSideRight,
             SoundIoChannelIdBackCenter,
         }
-    };
-    layouts[SoundIoChannelLayoutId6Point0Front] = {
+    },
+    {
         "6.0 (front)",
         6,
         {
@@ -174,8 +172,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontLeftCenter,
             SoundIoChannelIdFrontRightCenter,
         }
-    };
-    layouts[SoundIoChannelLayoutIdHexagonal] = {
+    },
+    {
         "Hexagonal",
         6,
         {
@@ -186,8 +184,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackRight,
             SoundIoChannelIdBackCenter,
         }
-    };
-    layouts[SoundIoChannelLayoutId6Point1] = {
+    },
+    {
         "6.1",
         7,
         {
@@ -199,8 +197,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackCenter,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId6Point1Back] = {
+    },
+    {
         "6.1 (back)",
         7,
         {
@@ -212,8 +210,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackCenter,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId6Point1Front] = {
+    },
+    {
         "6.1 (front)",
         7,
         {
@@ -225,8 +223,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontRightCenter,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId7Point0] = {
+    },
+    {
         "7.0",
         7,
         {
@@ -238,8 +236,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackLeft,
             SoundIoChannelIdBackRight,
         }
-    };
-    layouts[SoundIoChannelLayoutId7Point0Front] = {
+    },
+    {
         "7.0 (front)",
         7,
         {
@@ -251,8 +249,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontLeftCenter,
             SoundIoChannelIdFrontRightCenter,
         }
-    };
-    layouts[SoundIoChannelLayoutId7Point1] = {
+    },
+    {
         "7.1",
         8,
         {
@@ -265,8 +263,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackRight,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId7Point1Wide] = {
+    },
+    {
         "7.1 (wide)",
         8,
         {
@@ -279,8 +277,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontRightCenter,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutId7Point1WideBack] = {
+    },
+    {
         "7.1 (wide) (back)",
         8,
         {
@@ -293,8 +291,8 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdFrontRightCenter,
             SoundIoChannelIdLfe,
         }
-    };
-    layouts[SoundIoChannelLayoutIdOctagonal] = {
+    },
+    {
         "Octagonal",
         8,
         {
@@ -307,226 +305,82 @@ static struct SoundIoChannelLayout *make_builtin_channel_layouts()
             SoundIoChannelIdBackRight,
             SoundIoChannelIdBackCenter,
         }
-    };
-    return &layouts[0];
+    },
 };
-static struct SoundIoChannelLayout *builtin_channel_layouts = make_builtin_channel_layouts();
 
 #define CHANNEL_NAME_ALIAS_COUNT 3
 typedef const char *channel_names_t[CHANNEL_NAME_ALIAS_COUNT];
-static channel_names_t *make_channel_names()
-{
-    static channel_names_t names[SoundIoChannelIdMax];
-    names[SoundIoChannelIdInvalid][0] = "(Invalid Channel)";
-    names[SoundIoChannelIdInvalid][1] = NULL;
-    names[SoundIoChannelIdInvalid][2] = NULL;
-    names[SoundIoChannelIdFrontLeft][0] = "Front Left";
-    names[SoundIoChannelIdFrontLeft][1] = "FL";
-    names[SoundIoChannelIdFrontLeft][2] = "front-left";
-    names[SoundIoChannelIdFrontRight][0] = "Front Right";
-    names[SoundIoChannelIdFrontRight][1] = "FR";
-    names[SoundIoChannelIdFrontRight][2] = "front-right";
-    names[SoundIoChannelIdFrontCenter][0] = "Front Center";
-    names[SoundIoChannelIdFrontCenter][1] = "FC";
-    names[SoundIoChannelIdFrontCenter][2] = "front-center";
-    names[SoundIoChannelIdLfe][0] = "LFE";
-    names[SoundIoChannelIdLfe][1] = "LFE";
-    names[SoundIoChannelIdLfe][2] = "lfe";
-    names[SoundIoChannelIdBackLeft][0] = "Back Left";
-    names[SoundIoChannelIdBackLeft][1] = "BL";
-    names[SoundIoChannelIdBackLeft][2] = "rear-left";
-    names[SoundIoChannelIdBackRight][0] = "Back Right";
-    names[SoundIoChannelIdBackRight][1] = "BR";
-    names[SoundIoChannelIdBackRight][2] = "rear-right";
-    names[SoundIoChannelIdFrontLeftCenter][0] = "Front Left Center";
-    names[SoundIoChannelIdFrontLeftCenter][1] = "FLC";
-    names[SoundIoChannelIdFrontLeftCenter][2] = "front-left-of-center";
-    names[SoundIoChannelIdFrontRightCenter][0] = "Front Right Center";
-    names[SoundIoChannelIdFrontRightCenter][1] = "FRC";
-    names[SoundIoChannelIdFrontRightCenter][2] = "front-right-of-center";
-    names[SoundIoChannelIdBackCenter][0] = "Back Center";
-    names[SoundIoChannelIdBackCenter][1] = "BC";
-    names[SoundIoChannelIdBackCenter][2] = "rear-center";
-    names[SoundIoChannelIdSideLeft][0] = "Side Left";
-    names[SoundIoChannelIdSideLeft][1] = "SL";
-    names[SoundIoChannelIdSideLeft][2] = "side-left";
-    names[SoundIoChannelIdSideRight][0] = "Side Right";
-    names[SoundIoChannelIdSideRight][1] = "SR";
-    names[SoundIoChannelIdSideRight][2] = "side-right";
-    names[SoundIoChannelIdTopCenter][0] = "Top Center";
-    names[SoundIoChannelIdTopCenter][1] = "TC";
-    names[SoundIoChannelIdTopCenter][2] = "top-center";
-    names[SoundIoChannelIdTopFrontLeft][0] = "Top Front Left";
-    names[SoundIoChannelIdTopFrontLeft][1] = "TFL";
-    names[SoundIoChannelIdTopFrontLeft][2] = "top-front-left";
-    names[SoundIoChannelIdTopFrontCenter][0] = "Top Front Center";
-    names[SoundIoChannelIdTopFrontCenter][1] = "TFC";
-    names[SoundIoChannelIdTopFrontCenter][2] = "top-front-center";
-    names[SoundIoChannelIdTopFrontRight][0] = "Top Front Right";
-    names[SoundIoChannelIdTopFrontRight][1] = "TFR";
-    names[SoundIoChannelIdTopFrontRight][2] = "top-front-right";
-    names[SoundIoChannelIdTopBackLeft][0] = "Top Back Left";
-    names[SoundIoChannelIdTopBackLeft][1] = "TBL";
-    names[SoundIoChannelIdTopBackLeft][2] = "top-rear-left";
-    names[SoundIoChannelIdTopBackCenter][0] = "Top Back Center";
-    names[SoundIoChannelIdTopBackCenter][1] = "TBC";
-    names[SoundIoChannelIdTopBackCenter][2] = "top-rear-center";
-    names[SoundIoChannelIdTopBackRight][0] = "Top Back Right";
-    names[SoundIoChannelIdTopBackRight][1] = "TBR";
-    names[SoundIoChannelIdTopBackRight][2] = "top-rear-right";
-    names[SoundIoChannelIdBackLeftCenter][0] = "Back Left Center";
-    names[SoundIoChannelIdBackLeftCenter][1] = NULL;
-    names[SoundIoChannelIdBackLeftCenter][2] = NULL;
-    names[SoundIoChannelIdBackRightCenter][0] = "Back Right Center";
-    names[SoundIoChannelIdBackRightCenter][1] = NULL;
-    names[SoundIoChannelIdBackRightCenter][2] = NULL;
-    names[SoundIoChannelIdFrontLeftWide][0] = "Front Left Wide";
-    names[SoundIoChannelIdFrontLeftWide][1] = NULL;
-    names[SoundIoChannelIdFrontLeftWide][2] = NULL;
-    names[SoundIoChannelIdFrontRightWide][0] = "Front Right Wide";
-    names[SoundIoChannelIdFrontRightWide][1] = NULL;
-    names[SoundIoChannelIdFrontRightWide][2] = NULL;
-    names[SoundIoChannelIdFrontLeftHigh][0] = "Front Left High";
-    names[SoundIoChannelIdFrontLeftHigh][1] = NULL;
-    names[SoundIoChannelIdFrontLeftHigh][2] = NULL;
-    names[SoundIoChannelIdFrontCenterHigh][0] = "Front Center High";
-    names[SoundIoChannelIdFrontCenterHigh][1] = NULL;
-    names[SoundIoChannelIdFrontCenterHigh][2] = NULL;
-    names[SoundIoChannelIdFrontRightHigh][0] = "Front Right High";
-    names[SoundIoChannelIdFrontRightHigh][1] = NULL;
-    names[SoundIoChannelIdFrontRightHigh][2] = NULL;
-    names[SoundIoChannelIdTopFrontLeftCenter][0] = "Top Front Left Center";
-    names[SoundIoChannelIdTopFrontLeftCenter][1] = NULL;
-    names[SoundIoChannelIdTopFrontLeftCenter][2] = NULL;
-    names[SoundIoChannelIdTopFrontRightCenter][0] = "Top Front Right Center";
-    names[SoundIoChannelIdTopFrontRightCenter][1] = NULL;
-    names[SoundIoChannelIdTopFrontRightCenter][2] = NULL;
-    names[SoundIoChannelIdTopSideLeft][0] = "Top Side Left";
-    names[SoundIoChannelIdTopSideLeft][1] = NULL;
-    names[SoundIoChannelIdTopSideLeft][2] = NULL;
-    names[SoundIoChannelIdTopSideRight][0] = "Top Side Right";
-    names[SoundIoChannelIdTopSideRight][1] = NULL;
-    names[SoundIoChannelIdTopSideRight][2] = NULL;
-    names[SoundIoChannelIdLeftLfe][0] = "Left LFE";
-    names[SoundIoChannelIdLeftLfe][1] = NULL;
-    names[SoundIoChannelIdLeftLfe][2] = NULL;
-    names[SoundIoChannelIdRightLfe][0] = "Right LFE";
-    names[SoundIoChannelIdRightLfe][1] = NULL;
-    names[SoundIoChannelIdRightLfe][2] = NULL;
-    names[SoundIoChannelIdLfe2][0] = "LFE 2";
-    names[SoundIoChannelIdLfe2][1] = NULL;
-    names[SoundIoChannelIdLfe2][2] = NULL;
-    names[SoundIoChannelIdBottomCenter][0] = "Bottom Center";
-    names[SoundIoChannelIdBottomCenter][1] = NULL;
-    names[SoundIoChannelIdBottomCenter][2] = NULL;
-    names[SoundIoChannelIdBottomLeftCenter][0] = "Bottom Left Center";
-    names[SoundIoChannelIdBottomLeftCenter][1] = NULL;
-    names[SoundIoChannelIdBottomLeftCenter][2] = NULL;
-    names[SoundIoChannelIdBottomRightCenter][0] = "Bottom Right Center";
-    names[SoundIoChannelIdBottomRightCenter][1] = NULL;
-    names[SoundIoChannelIdBottomRightCenter][2] = NULL;
-    names[SoundIoChannelIdMsMid][0] = "Mid/Side Mid";
-    names[SoundIoChannelIdMsMid][1] = NULL;
-    names[SoundIoChannelIdMsMid][2] = NULL;
-    names[SoundIoChannelIdMsSide][0] = "Mid/Side Side";
-    names[SoundIoChannelIdMsSide][1] = NULL;
-    names[SoundIoChannelIdMsSide][2] = NULL;
-    names[SoundIoChannelIdAmbisonicW][0] = "Ambisonic W";
-    names[SoundIoChannelIdAmbisonicW][1] = NULL;
-    names[SoundIoChannelIdAmbisonicW][2] = NULL;
-    names[SoundIoChannelIdAmbisonicX][0] = "Ambisonic X";
-    names[SoundIoChannelIdAmbisonicX][1] = NULL;
-    names[SoundIoChannelIdAmbisonicX][2] = NULL;
-    names[SoundIoChannelIdAmbisonicY][0] = "Ambisonic Y";
-    names[SoundIoChannelIdAmbisonicY][1] = NULL;
-    names[SoundIoChannelIdAmbisonicY][2] = NULL;
-    names[SoundIoChannelIdAmbisonicZ][0] = "Ambisonic Z";
-    names[SoundIoChannelIdAmbisonicZ][1] = NULL;
-    names[SoundIoChannelIdAmbisonicZ][2] = NULL;
-    names[SoundIoChannelIdXyX][0] = "X-Y X";
-    names[SoundIoChannelIdXyX][1] = NULL;
-    names[SoundIoChannelIdXyX][2] = NULL;
-    names[SoundIoChannelIdXyY][0] = "X-Y Y";
-    names[SoundIoChannelIdXyY][1] = NULL;
-    names[SoundIoChannelIdXyY][2] = NULL;
-    names[SoundIoChannelIdHeadphonesLeft][0] = "Headphones Left";
-    names[SoundIoChannelIdHeadphonesLeft][1] = NULL;
-    names[SoundIoChannelIdHeadphonesLeft][2] = NULL;
-    names[SoundIoChannelIdHeadphonesRight][0] = "Headphones Right";
-    names[SoundIoChannelIdHeadphonesRight][1] = NULL;
-    names[SoundIoChannelIdHeadphonesRight][2] = NULL;
-    names[SoundIoChannelIdClickTrack][0] = "Click Track";
-    names[SoundIoChannelIdClickTrack][1] = NULL;
-    names[SoundIoChannelIdClickTrack][2] = NULL;
-    names[SoundIoChannelIdForeignLanguage][0] = "Foreign Language";
-    names[SoundIoChannelIdForeignLanguage][1] = NULL;
-    names[SoundIoChannelIdForeignLanguage][2] = NULL;
-    names[SoundIoChannelIdHearingImpaired][0] = "Hearing Impaired";
-    names[SoundIoChannelIdHearingImpaired][1] = NULL;
-    names[SoundIoChannelIdHearingImpaired][2] = NULL;
-    names[SoundIoChannelIdNarration][0] = "Narration";
-    names[SoundIoChannelIdNarration][1] = NULL;
-    names[SoundIoChannelIdNarration][2] = NULL;
-    names[SoundIoChannelIdHaptic][0] = "Haptic";
-    names[SoundIoChannelIdHaptic][1] = NULL;
-    names[SoundIoChannelIdHaptic][2] = NULL;
-    names[SoundIoChannelIdDialogCentricMix][0] = "Dialog Centric Mix";
-    names[SoundIoChannelIdDialogCentricMix][1] = NULL;
-    names[SoundIoChannelIdDialogCentricMix][2] = NULL;
-    names[SoundIoChannelIdAux][0] = "Aux";
-    names[SoundIoChannelIdAux][1] = NULL;
-    names[SoundIoChannelIdAux][2] = NULL;
-    names[SoundIoChannelIdAux0][0] = "Aux 0";
-    names[SoundIoChannelIdAux0][1] = NULL;
-    names[SoundIoChannelIdAux0][2] = NULL;
-    names[SoundIoChannelIdAux1][0] = "Aux 1";
-    names[SoundIoChannelIdAux1][1] = NULL;
-    names[SoundIoChannelIdAux1][2] = NULL;
-    names[SoundIoChannelIdAux2][0] = "Aux 2";
-    names[SoundIoChannelIdAux2][1] = NULL;
-    names[SoundIoChannelIdAux2][2] = NULL;
-    names[SoundIoChannelIdAux3][0] = "Aux 3";
-    names[SoundIoChannelIdAux3][1] = NULL;
-    names[SoundIoChannelIdAux3][2] = NULL;
-    names[SoundIoChannelIdAux4][0] = "Aux 4";
-    names[SoundIoChannelIdAux4][1] = NULL;
-    names[SoundIoChannelIdAux4][2] = NULL;
-    names[SoundIoChannelIdAux5][0] = "Aux 5";
-    names[SoundIoChannelIdAux5][1] = NULL;
-    names[SoundIoChannelIdAux5][2] = NULL;
-    names[SoundIoChannelIdAux6][0] = "Aux 6";
-    names[SoundIoChannelIdAux6][1] = NULL;
-    names[SoundIoChannelIdAux6][2] = NULL;
-    names[SoundIoChannelIdAux7][0] = "Aux 7";
-    names[SoundIoChannelIdAux7][1] = NULL;
-    names[SoundIoChannelIdAux7][2] = NULL;
-    names[SoundIoChannelIdAux8][0] = "Aux 8";
-    names[SoundIoChannelIdAux8][1] = NULL;
-    names[SoundIoChannelIdAux8][2] = NULL;
-    names[SoundIoChannelIdAux9][0] = "Aux 9";
-    names[SoundIoChannelIdAux9][1] = NULL;
-    names[SoundIoChannelIdAux9][2] = NULL;
-    names[SoundIoChannelIdAux10][0] = "Aux 10";
-    names[SoundIoChannelIdAux10][1] = NULL;
-    names[SoundIoChannelIdAux10][2] = NULL;
-    names[SoundIoChannelIdAux11][0] = "Aux 11";
-    names[SoundIoChannelIdAux11][1] = NULL;
-    names[SoundIoChannelIdAux11][2] = NULL;
-    names[SoundIoChannelIdAux12][0] = "Aux 12";
-    names[SoundIoChannelIdAux12][1] = NULL;
-    names[SoundIoChannelIdAux12][2] = NULL;
-    names[SoundIoChannelIdAux13][0] = "Aux 13";
-    names[SoundIoChannelIdAux13][1] = NULL;
-    names[SoundIoChannelIdAux13][2] = NULL;
-    names[SoundIoChannelIdAux14][0] = "Aux 14";
-    names[SoundIoChannelIdAux14][1] = NULL;
-    names[SoundIoChannelIdAux14][2] = NULL;
-    names[SoundIoChannelIdAux15][0] = "Aux 15";
-    names[SoundIoChannelIdAux15][1] = NULL;
-    names[SoundIoChannelIdAux15][2] = NULL;
-    return &names[0];
+static channel_names_t channel_names[] = {
+    {"(Invalid Channel)", NULL, NULL},
+    {"Front Left", "FL", "front-left"},
+    {"Front Right", "FR", "front-right"},
+    {"Front Center", "FC", "front-center"},
+    {"LFE", "LFE", "lfe"},
+    {"Back Left", "BL", "rear-left"},
+    {"Back Right", "BR", "rear-right"},
+    {"Front Left Center", "FLC", "front-left-of-center"},
+    {"Front Right Center", "FRC", "front-right-of-center"},
+    {"Back Center", "BC", "rear-center"},
+    {"Side Left", "SL", "side-left"},
+    {"Side Right", "SR", "side-right"},
+    {"Top Center", "TC", "top-center"},
+    {"Top Front Left", "TFL", "top-front-left"},
+    {"Top Front Center", "TFC", "top-front-center"},
+    {"Top Front Right", "TFR", "top-front-right"},
+    {"Top Back Left", "TBL", "top-rear-left"},
+    {"Top Back Center", "TBC", "top-rear-center"},
+    {"Top Back Right", "TBR", "top-rear-right"},
+    {"Back Left Center", NULL, NULL},
+    {"Back Right Center", NULL, NULL},
+    {"Front Left Wide", NULL, NULL},
+    {"Front Right Wide", NULL, NULL},
+    {"Front Left High", NULL, NULL},
+    {"Front Center High", NULL, NULL},
+    {"Front Right High", NULL, NULL},
+    {"Top Front Left Center", NULL, NULL},
+    {"Top Front Right Center", NULL, NULL},
+    {"Top Side Left", NULL, NULL},
+    {"Top Side Right", NULL, NULL},
+    {"Left LFE", NULL, NULL},
+    {"Right LFE", NULL, NULL},
+    {"LFE 2", NULL, NULL},
+    {"Bottom Center", NULL, NULL},
+    {"Bottom Left Center", NULL, NULL},
+    {"Bottom Right Center", NULL, NULL},
+    {"Mid/Side Mid", NULL, NULL},
+    {"Mid/Side Side", NULL, NULL},
+    {"Ambisonic W", NULL, NULL},
+    {"Ambisonic X", NULL, NULL},
+    {"Ambisonic Y", NULL, NULL},
+    {"Ambisonic Z", NULL, NULL},
+    {"X-Y X", NULL, NULL},
+    {"X-Y Y", NULL, NULL},
+    {"Headphones Left", NULL, NULL},
+    {"Headphones Right", NULL, NULL},
+    {"Click Track", NULL, NULL},
+    {"Foreign Language", NULL, NULL},
+    {"Hearing Impaired", NULL, NULL},
+    {"Narration", NULL, NULL},
+    {"Haptic", NULL, NULL},
+    {"Dialog Centric Mix", NULL, NULL},
+    {"Aux", NULL, NULL},
+    {"Aux 0", NULL, NULL},
+    {"Aux 1", NULL, NULL},
+    {"Aux 2", NULL, NULL},
+    {"Aux 3", NULL, NULL},
+    {"Aux 4", NULL, NULL},
+    {"Aux 5", NULL, NULL},
+    {"Aux 6", NULL, NULL},
+    {"Aux 7", NULL, NULL},
+    {"Aux 8", NULL, NULL},
+    {"Aux 9", NULL, NULL},
+    {"Aux 10", NULL, NULL},
+    {"Aux 11", NULL, NULL},
+    {"Aux 12", NULL, NULL},
+    {"Aux 13", NULL, NULL},
+    {"Aux 14", NULL, NULL},
+    {"Aux 15", NULL, NULL},
 };
-static channel_names_t *channel_names = make_channel_names();
 
 const char *soundio_get_channel_name(enum SoundIoChannelId id) {
     if (id >= ARRAY_LENGTH(channel_names))

--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -152,7 +152,7 @@ static void destroy_ca(struct SoundIoPrivate *si) {
     SoundIoListAudioDeviceID_deinit(&sica->registered_listeners);
 
     if (sica->thread) {
-        atomic_flag_clear(&sica->abort_flag);
+        SOUNDIO_ATOMIC_FLAG_CLEAR(sica->abort_flag);
         soundio_os_cond_signal(sica->scan_devices_cond, NULL);
         soundio_os_thread_destroy(sica->thread);
     }
@@ -846,7 +846,7 @@ static void device_thread_run(void *arg) {
     int err;
 
     for (;;) {
-        if (!atomic_flag_test_and_set(&sica->abort_flag))
+        if (!SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(sica->abort_flag))
             break;
         if (SOUNDIO_ATOMIC_LOAD(sica->service_restarted)) {
             shutdown_backend(si, SoundIoErrorBackendDisconnected);
@@ -1122,7 +1122,7 @@ static OSStatus read_callback_ca(void *userdata, AudioUnitRenderActionFlags *io_
     }
 
     OSStatus os_err;
-    if ((os_err = AudioUnitRender(isca->instance, io_action_flags, in_time_stamp, 
+    if ((os_err = AudioUnitRender(isca->instance, io_action_flags, in_time_stamp,
         in_bus_number, in_number_frames, isca->buffer_list)))
     {
         instream->error_callback(instream, SoundIoErrorStreaming);
@@ -1348,7 +1348,7 @@ int soundio_coreaudio_init(struct SoundIoPrivate *si) {
     SOUNDIO_ATOMIC_STORE(sica->have_devices_flag, false);
     SOUNDIO_ATOMIC_STORE(sica->device_scan_queued, true);
     SOUNDIO_ATOMIC_STORE(sica->service_restarted, false);
-    atomic_flag_test_and_set(&sica->abort_flag);
+    SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(sica->abort_flag);
 
     sica->mutex = soundio_os_mutex_create();
     if (!sica->mutex) {

--- a/src/coreaudio.h
+++ b/src/coreaudio.h
@@ -30,7 +30,7 @@ struct SoundIoCoreAudio {
     struct SoundIoOsMutex *mutex;
     struct SoundIoOsCond *cond;
     struct SoundIoOsThread *thread;
-    atomic_flag abort_flag;
+    struct SoundIoAtomicFlag abort_flag;
 
     // this one is ready to be read with flush_events. protected by mutex
     struct SoundIoDevicesInfo *ready_devices_info;

--- a/src/dummy.h
+++ b/src/dummy.h
@@ -27,14 +27,14 @@ struct SoundIoDeviceDummy { int make_the_struct_not_empty; };
 struct SoundIoOutStreamDummy {
     struct SoundIoOsThread *thread;
     struct SoundIoOsCond *cond;
-    atomic_flag abort_flag;
+    struct SoundIoAtomicFlag abort_flag;
     double period_duration;
     int buffer_frame_count;
     int frames_left;
     int write_frame_count;
     struct SoundIoRingBuffer ring_buffer;
     double playback_start_time;
-    atomic_flag clear_buffer_flag;
+    struct SoundIoAtomicFlag clear_buffer_flag;
     struct SoundIoAtomicBool pause_requested;
     struct SoundIoChannelArea areas[SOUNDIO_MAX_CHANNELS];
 };
@@ -42,7 +42,7 @@ struct SoundIoOutStreamDummy {
 struct SoundIoInStreamDummy {
     struct SoundIoOsThread *thread;
     struct SoundIoOsCond *cond;
-    atomic_flag abort_flag;
+    struct SoundIoAtomicFlag abort_flag;
     double period_duration;
     int frames_left;
     int read_frame_count;

--- a/src/jack.h
+++ b/src/jack.h
@@ -38,7 +38,7 @@ struct SoundIoJack {
     jack_client_t *client;
     struct SoundIoOsMutex *mutex;
     struct SoundIoOsCond *cond;
-    atomic_flag refresh_devices_flag;
+    struct SoundIoAtomicFlag refresh_devices_flag;
     int sample_rate;
     int period_size;
     bool is_shutdown;

--- a/src/list.h
+++ b/src/list.h
@@ -25,28 +25,28 @@
 
 #define SOUNDIO_MAKE_LIST_PROTO(Type, Name, static_kw) \
     static_kw void Name##_deinit(struct Name *s); \
-    static_kw int __attribute__((warn_unused_result)) Name##_append(struct Name *s, Type item); \
+    static_kw int SOUNDIO_ATTR_WARN_UNUSED_RESULT Name##_append(struct Name *s, Type item); \
     static_kw Type Name##_val_at(struct Name *s, int index); \
     static_kw Type * Name##_ptr_at(struct Name *s, int index); \
     static_kw Type Name##_pop(struct Name *s); \
-    static_kw int __attribute__((warn_unused_result)) Name##_add_one(struct Name *s); \
+    static_kw int SOUNDIO_ATTR_WARN_UNUSED_RESULT Name##_add_one(struct Name *s); \
     static_kw Type Name##_last_val(struct Name *s); \
     static_kw Type *Name##_last_ptr(struct Name *s); \
-    static_kw int __attribute__((warn_unused_result)) Name##_resize(struct Name *s, int new_length); \
+    static_kw int SOUNDIO_ATTR_WARN_UNUSED_RESULT Name##_resize(struct Name *s, int new_length); \
     static_kw void Name##_clear(struct Name *s); \
-    static_kw int __attribute__((warn_unused_result)) \
+    static_kw int SOUNDIO_ATTR_WARN_UNUSED_RESULT \
         Name##_ensure_capacity(struct Name *s, int new_capacity); \
     static_kw Type Name##_swap_remove(struct Name *s, int index);
 
 
 #define SOUNDIO_MAKE_LIST_DEF(Type, Name, static_kw) \
-    __attribute__ ((unused)) \
+    SOUNDIO_ATTR_UNUSED \
     static_kw void Name##_deinit(struct Name *s) { \
         free(s->items); \
     } \
 \
-    __attribute__ ((unused)) \
-    __attribute__ ((warn_unused_result)) \
+    SOUNDIO_ATTR_UNUSED \
+    SOUNDIO_ATTR_WARN_UNUSED_RESULT \
     static_kw int Name##_ensure_capacity(struct Name *s, int new_capacity) { \
         int better_capacity = soundio_int_max(s->capacity, 16); \
         while (better_capacity < new_capacity) \
@@ -61,8 +61,8 @@
         return 0; \
     } \
 \
-    __attribute__ ((unused)) \
-    __attribute__ ((warn_unused_result)) \
+    SOUNDIO_ATTR_UNUSED \
+    SOUNDIO_ATTR_WARN_UNUSED_RESULT \
     static_kw int Name##_append(struct Name *s, Type item) { \
         int err = Name##_ensure_capacity(s, s->length + 1); \
         if (err) \
@@ -72,7 +72,7 @@
         return 0; \
     } \
 \
-    __attribute__ ((unused)) \
+    SOUNDIO_ATTR_UNUSED \
     static_kw Type Name##_val_at(struct Name *s, int index) {                                            \
         assert(index >= 0);                                                              \
         assert(index < s->length);                                                          \
@@ -82,22 +82,22 @@
     /* remember that the pointer to this item is invalid after you \
      * modify the length of the list \
      */ \
-    __attribute__ ((unused)) \
+    SOUNDIO_ATTR_UNUSED \
     static_kw Type * Name##_ptr_at(struct Name *s, int index) { \
         assert(index >= 0); \
         assert(index < s->length); \
         return &s->items[index]; \
     } \
 \
-    __attribute__ ((unused)) \
+    SOUNDIO_ATTR_UNUSED \
     static_kw Type Name##_pop(struct Name *s) { \
         assert(s->length >= 1); \
         s->length -= 1; \
         return s->items[s->length]; \
     }                                                                                    \
 \
-    __attribute__ ((unused)) \
-    __attribute__ ((warn_unused_result)) \
+    SOUNDIO_ATTR_UNUSED \
+    SOUNDIO_ATTR_WARN_UNUSED_RESULT \
     static_kw int Name##_resize(struct Name *s, int new_length) {    \
         assert(new_length >= 0);                                                         \
         int err = Name##_ensure_capacity(s, new_length);                                           \
@@ -107,30 +107,30 @@
         return 0;                                                                        \
     }                                                                                    \
 \
-    __attribute__ ((unused)) \
-    __attribute__ ((warn_unused_result)) \
+    SOUNDIO_ATTR_UNUSED \
+    SOUNDIO_ATTR_WARN_UNUSED_RESULT \
     static_kw int Name##_add_one(struct Name *s) { \
         return Name##_resize(s, s->length + 1); \
     } \
 \
-    __attribute__ ((unused)) \
+    SOUNDIO_ATTR_UNUSED \
     static_kw Type Name##_last_val(struct Name *s) {                                                   \
         assert(s->length >= 1);                                                             \
         return s->items[s->length - 1];                                                        \
     }                                                                                    \
 \
-    __attribute__ ((unused)) \
+    SOUNDIO_ATTR_UNUSED \
     static_kw Type *Name##_last_ptr(struct Name *s) {                                                  \
         assert(s->length >= 1);                                                             \
         return &s->items[s->length - 1];                                                       \
     }                                                                                    \
 \
-    __attribute__ ((unused)) \
+    SOUNDIO_ATTR_UNUSED \
     static_kw void Name##_clear(struct Name *s) {                                                      \
         s->length = 0;                                                                      \
     }                                                                                    \
 \
-    __attribute__ ((unused)) \
+    SOUNDIO_ATTR_UNUSED \
     static_kw Type Name##_swap_remove(struct Name *s, int index) { \
         assert(index >= 0); \
         assert(index < s->length); \

--- a/src/pulseaudio.c
+++ b/src/pulseaudio.c
@@ -667,7 +667,7 @@ static int outstream_open_pa(struct SoundIoPrivate *si, struct SoundIoOutStreamP
 
     struct SoundIoPulseAudio *sipa = &si->backend_data.pulseaudio;
     SOUNDIO_ATOMIC_STORE(ospa->stream_ready, false);
-    atomic_flag_test_and_set(&ospa->clear_buffer_flag);
+    SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(ospa->clear_buffer_flag);
 
     assert(sipa->pulse_context);
 
@@ -783,7 +783,7 @@ static int outstream_end_write_pa(struct SoundIoPrivate *si, struct SoundIoOutSt
     struct SoundIoOutStreamPulseAudio *ospa = &os->backend_data.pulseaudio;
     pa_stream *stream = ospa->stream;
 
-    pa_seek_mode_t seek_mode = atomic_flag_test_and_set(&ospa->clear_buffer_flag) ? PA_SEEK_RELATIVE : PA_SEEK_RELATIVE_ON_READ;
+    pa_seek_mode_t seek_mode = SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(ospa->clear_buffer_flag) ? PA_SEEK_RELATIVE : PA_SEEK_RELATIVE_ON_READ;
     if (pa_stream_write(stream, ospa->write_ptr, ospa->write_byte_count, NULL, 0, seek_mode))
         return SoundIoErrorStreaming;
 
@@ -794,7 +794,7 @@ static int outstream_clear_buffer_pa(struct SoundIoPrivate *si,
         struct SoundIoOutStreamPrivate *os)
 {
     struct SoundIoOutStreamPulseAudio *ospa = &os->backend_data.pulseaudio;
-    atomic_flag_clear(&ospa->clear_buffer_flag);
+    SOUNDIO_ATOMIC_FLAG_CLEAR(ospa->clear_buffer_flag);
     return 0;
 }
 

--- a/src/pulseaudio.h
+++ b/src/pulseaudio.h
@@ -46,7 +46,7 @@ struct SoundIoOutStreamPulseAudio {
     pa_buffer_attr buffer_attr;
     char *write_ptr;
     size_t write_byte_count;
-    atomic_flag clear_buffer_flag;
+    struct SoundIoAtomicFlag clear_buffer_flag;
     struct SoundIoChannelArea areas[SOUNDIO_MAX_CHANNELS];
 };
 

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -34,28 +34,39 @@ static const enum SoundIoBackend available_backends[] = {
 };
 
 typedef int (*backend_init_t)(struct SoundIoPrivate *);
-static backend_init_t *make_backend_init_fns()
-{
-    static backend_init_t fns[6] = { 0 };
+static backend_init_t backend_init_fns[] = {
 #ifdef SOUNDIO_HAVE_JACK
-    fns[SoundIoBackendJack] = soundio_jack_init;
+    &soundio_jack_init,
+#else
+    NULL,
 #endif
+
 #ifdef SOUNDIO_HAVE_PULSEAUDIO
-    fns[SoundIoBackendPulseAudio] = soundio_pulseaudio_init;
+    &soundio_pulseaudio_init,
+#else
+    NULL,
 #endif
+
 #ifdef SOUNDIO_HAVE_ALSA
-    fns[SoundIoBackendAlsa] = soundio_alsa_init;
+    &soundio_alsa_init,
+#else
+    NULL,
 #endif
+
 #ifdef SOUNDIO_HAVE_COREAUDIO
-    fns[SoundIoBackendCoreAudio] = soundio_coreaudio_init;
+    &soundio_coreaudio_init,
+#else
+    NULL,
 #endif
+
 #ifdef SOUNDIO_HAVE_WASAPI
-    fns[SoundIoBackendWasapi] = soundio_wasapi_init;
+    soundio_wasapi_init,
+#else
+    NULL,
 #endif
-    fns[SoundIoBackendDummy] = soundio_dummy_init;
-    return &fns[0];
-}
-static backend_init_t *backend_init_fns = make_backend_init_fns();
+
+    &soundio_dummy_init,
+};
 
 SOUNDIO_MAKE_LIST_DEF(struct SoundIoDevice*, SoundIoListDevicePtr, SOUNDIO_LIST_NOT_STATIC)
 SOUNDIO_MAKE_LIST_DEF(struct SoundIoSampleRateRange, SoundIoListSampleRateRange, SOUNDIO_LIST_NOT_STATIC)

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -33,36 +33,29 @@ static const enum SoundIoBackend available_backends[] = {
     SoundIoBackendDummy,
 };
 
-static int (*backend_init_fns[])(struct SoundIoPrivate *) = {
-    [SoundIoBackendNone] = NULL,
+typedef int (*backend_init_t)(struct SoundIoPrivate *);
+static backend_init_t *make_backend_init_fns()
+{
+    static backend_init_t fns[6] = { 0 };
 #ifdef SOUNDIO_HAVE_JACK
-    [SoundIoBackendJack] = soundio_jack_init,
-#else
-    [SoundIoBackendJack] = NULL,
+    fns[SoundIoBackendJack] = soundio_jack_init;
 #endif
 #ifdef SOUNDIO_HAVE_PULSEAUDIO
-    [SoundIoBackendPulseAudio] = soundio_pulseaudio_init,
-#else
-    [SoundIoBackendPulseAudio] = NULL,
+    fns[SoundIoBackendPulseAudio] = soundio_pulseaudio_init;
 #endif
 #ifdef SOUNDIO_HAVE_ALSA
-    [SoundIoBackendAlsa] = soundio_alsa_init,
-#else
-    [SoundIoBackendAlsa] = NULL,
+    fns[SoundIoBackendAlsa] = soundio_alsa_init;
 #endif
 #ifdef SOUNDIO_HAVE_COREAUDIO
-    [SoundIoBackendCoreAudio] = soundio_coreaudio_init,
-#else
-    [SoundIoBackendCoreAudio] = NULL,
+    fns[SoundIoBackendCoreAudio] = soundio_coreaudio_init;
 #endif
 #ifdef SOUNDIO_HAVE_WASAPI
-    [SoundIoBackendWasapi] = soundio_wasapi_init,
-#else
-    [SoundIoBackendWasapi] = NULL,
+    fns[SoundIoBackendWasapi] = soundio_wasapi_init;
 #endif
-    [SoundIoBackendDummy] = soundio_dummy_init,
-};
-
+    fns[SoundIoBackendDummy] = soundio_dummy_init;
+    return &fns[0];
+}
+static backend_init_t *backend_init_fns = make_backend_init_fns();
 
 SOUNDIO_MAKE_LIST_DEF(struct SoundIoDevice*, SoundIoListDevicePtr, SOUNDIO_LIST_NOT_STATIC)
 SOUNDIO_MAKE_LIST_DEF(struct SoundIoSampleRateRange, SoundIoListSampleRateRange, SOUNDIO_LIST_NOT_STATIC)

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -171,9 +171,9 @@ static void default_backend_disconnect_cb(struct SoundIo *soundio, int err) {
     soundio_panic("libsoundio: backend disconnected: %s", soundio_strerror(err));
 }
 
-static atomic_flag rtprio_seen = ATOMIC_FLAG_INIT;
+static struct SoundIoAtomicFlag rtprio_seen = SOUNDIO_ATOMIC_FLAG_INIT;
 static void default_emit_rtprio_warning(void) {
-    if (!atomic_flag_test_and_set(&rtprio_seen)) {
+    if (!SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(rtprio_seen)) {
         fprintf(stderr, "warning: unable to set high priority thread: Operation not permitted\n");
         fprintf(stderr, "See "
             "https://github.com/andrewrk/genesis/wiki/warning:-unable-to-set-high-priority-thread:-Operation-not-permitted\n");

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -35,6 +35,8 @@ static const enum SoundIoBackend available_backends[] = {
 
 typedef int (*backend_init_t)(struct SoundIoPrivate *);
 static backend_init_t backend_init_fns[] = {
+    NULL, // None backend
+
 #ifdef SOUNDIO_HAVE_JACK
     &soundio_jack_init,
 #else

--- a/src/util.h
+++ b/src/util.h
@@ -13,11 +13,11 @@
 #include <assert.h>
 #include <stdbool.h>
 
-#define ALLOCATE_NONZERO(Type, count) malloc((count) * sizeof(Type))
+#define ALLOCATE_NONZERO(Type, count) ((Type*)malloc((count) * sizeof(Type)))
 
-#define ALLOCATE(Type, count) calloc(count, sizeof(Type))
+#define ALLOCATE(Type, count) ((Type*)calloc(count, sizeof(Type)))
 
-#define REALLOCATE_NONZERO(Type, old, new_count) realloc(old, (new_count) * sizeof(Type))
+#define REALLOCATE_NONZERO(Type, old, new_count) ((Type*)realloc(old, (new_count) * sizeof(Type)))
 
 #define ARRAY_LENGTH(array) (sizeof(array)/sizeof((array)[0]))
 

--- a/src/util.h
+++ b/src/util.h
@@ -21,6 +21,21 @@
 
 #define ARRAY_LENGTH(array) (sizeof(array)/sizeof((array)[0]))
 
+#ifdef _MSC_VER
+#define SOUNDIO_ATTR_COLD
+#define SOUNDIO_ATTR_NORETURN __declspec(noreturn)
+#define SOUNDIO_ATTR_FORMAT(...)
+#define SOUNDIO_ATTR_UNUSED __pragma(warning(suppress:4100))
+#define SOUNDIO_ATTR_WARN_UNUSED_RESULT _Check_return_
+#else
+#define SOUNDIO_ATTR_COLD __attribute__((cold))
+#define SOUNDIO_ATTR_NORETURN __attribute__((noreturn))
+#define SOUNDIO_ATTR_FORMAT(...) __attribute__((format(__VA_ARGS__)))
+#define SOUNDIO_ATTR_UNUSED __attribute__((unused))
+#define SOUNDIO_ATTR_WARN_UNUSED_RESULT __attribute__((warn_unused_result))
+#endif
+
+
 static inline int soundio_int_min(int a, int b) {
     return (a <= b) ? a : b;
 }
@@ -45,13 +60,14 @@ static inline double soundio_double_clamp(double min_value, double value, double
     return soundio_double_max(soundio_double_min(value, max_value), min_value);
 }
 
+SOUNDIO_ATTR_NORETURN
 void soundio_panic(const char *format, ...)
-    __attribute__((cold))
-    __attribute__ ((noreturn))
-    __attribute__ ((format (printf, 1, 2)));
+    SOUNDIO_ATTR_COLD
+    SOUNDIO_ATTR_FORMAT(printf, 1, 2)
+    ;
 
 char *soundio_alloc_sprintf(int *len, const char *format, ...)
-    __attribute__ ((format (printf, 2, 3)));
+    SOUNDIO_ATTR_FORMAT(printf, 2, 3);
 
 static inline char *soundio_str_dupe(const char *str, int str_len) {
     char *out = ALLOCATE_NONZERO(char, str_len + 1);

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -5,10 +5,93 @@
  * See http://opensource.org/licenses/MIT
  */
 
+#define INITGUID
+#define CINTERFACE
+#define COBJMACROS
+#define CONST_VTABLE
+#include <initguid.h>
+#include <audioclient.h>
+#include <endpointvolume.h>
+#include <mmdeviceapi.h>
+#include <mmreg.h>
+#include <functiondiscoverykeys_devpkey.h>
+
 #include "wasapi.h"
 #include "soundio_private.h"
 
 #include <stdio.h>
+
+#ifdef __cplusplus
+// In C++ mode, IsEqualGUID() takes its arguments by reference
+#define IS_EQUAL_GUID(a, b) IsEqualGUID(*(a), *(b))
+#define IS_EQUAL_IID(a, b) IsEqualIID((a), *(b))
+
+// And some constants are passed by reference
+#define IID_IAUDIOCLIENT                      (IID_IAudioClient)
+#define IID_IMMENDPOINT                       (IID_IMMEndpoint)
+#define IID_IAUDIOCLOCKADJUSTMENT             (IID_IAudioClockAdjustment)
+#define IID_IAUDIOSESSIONCONTROL              (IID_IAudioSessionControl)
+#define IID_IAUDIORENDERCLIENT                (IID_IAudioRenderClient)
+#define IID_IMMDEVICEENUMERATOR               (IID_IMMDeviceEnumerator)
+#define IID_IAUDIOCAPTURECLIENT               (IID_IAudioCaptureClient)
+#define CLSID_MMDEVICEENUMERATOR              (CLSID_MMDeviceEnumerator)
+#define PKEY_DEVICE_FRIENDLYNAME              (PKEY_Device_FriendlyName)
+#define PKEY_AUDIOENGINE_DEVICEFORMAT         (PKEY_AudioEngine_DeviceFormat)
+
+// And some GUID are never implemented (Ignoring the INITGUID define)
+static const CLSID CLSID_MMDeviceEnumerator  = __uuidof(MMDeviceEnumerator);
+static const IID   IID_IMMDeviceEnumerator   = {
+    //MIDL_INTERFACE("A95664D2-9614-4F35-A746-DE8DB63617E6")
+    0xa95664d2, 0x9614, 0x4f35, {0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6}
+};
+static const IID   IID_IMMNotificationClient = {
+    //MIDL_INTERFACE("7991EEC9-7E89-4D85-8390-6C703CEC60C0")
+    0x7991eec9, 0x7e89, 0x4d85, {0x83, 0x90, 0x6c, 0x70, 0x3c, 0xec, 0x60, 0xc0}
+};
+static const IID   IID_IAudioClient = {
+    //MIDL_INTERFACE("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2")
+    0x1cb9ad4c, 0xdbfa, 0x4c32, {0xb1, 0x78, 0xc2, 0xf5, 0x68, 0xa7, 0x03, 0xb2}
+};
+static const IID   IID_IAudioRenderClient    = {
+    //MIDL_INTERFACE("F294ACFC-3146-4483-A7BF-ADDCA7C260E2")
+    0xf294acfc, 0x3146, 0x4483, {0xa7, 0xbf, 0xad, 0xdc, 0xa7, 0xc2, 0x60, 0xe2}
+};
+static const IID   IID_IAudioSessionControl  = {
+    //MIDL_INTERFACE("F4B1A599-7266-4319-A8CA-E70ACB11E8CD")
+    0xf4b1a599, 0x7266, 0x4319, {0xa8, 0xca, 0xe7, 0x0a, 0xcb, 0x11, 0xe8, 0xcd}
+};
+static const IID   IID_IAudioSessionEvents   = {
+    //MIDL_INTERFACE("24918ACC-64B3-37C1-8CA9-74A66E9957A8")
+    0x24918acc, 0x64b3, 0x37c1, {0x8c, 0xa9, 0x74, 0xa6, 0x6e, 0x99, 0x57, 0xa8}
+};
+static const IID IID_IMMEndpoint = {
+    //MIDL_INTERFACE("1BE09788-6894-4089-8586-9A2A6C265AC5")
+    0x1be09788, 0x6894, 0x4089, {0x85, 0x86, 0x9a, 0x2a, 0x6c, 0x26, 0x5a, 0xc5}
+};
+static const IID IID_IAudioClockAdjustment = {
+    //MIDL_INTERFACE("f6e4c0a0-46d9-4fb8-be21-57a3ef2b626c")
+    0xf6e4c0a0, 0x46d9, 0x4fb8, {0xbe, 0x21, 0x57, 0xa3, 0xef, 0x2b, 0x62, 0x6c}
+};
+static const IID IID_IAudioCaptureClient = {
+    //MIDL_INTERFACE("C8ADBD64-E71E-48a0-A4DE-185C395CD317")
+    0xc8adbd64, 0xe71e, 0x48a0, {0xa4, 0xde, 0x18, 0x5c, 0x39, 0x5c, 0xd3, 0x17}
+};
+
+#else
+#define IS_EQUAL_GUID(a, b) IsEqualGUID((a), (b))
+#define IS_EQUAL_IID(a, b) IsEqualIID((a), (b))
+
+#define IID_IAUDIOCLIENT (&IID_IAudioClient)
+#define IID_IMMENDPOINT (&IID_IMMEndpoint)
+#define PKEY_DEVICE_FRIENDLYNAME (&PKEY_Device_FriendlyName)
+#define PKEY_AUDIOENGINE_DEVICEFORMAT (&PKEY_AudioEngine_DeviceFormat)
+#define CLSID_MMDEVICEENUMERATOR (&CLSID_MMDeviceEnumerator)
+#define IID_IAUDIOCLOCKADJUSTMENT (&IID_IAudioClockAdjustment)
+#define IID_IAUDIOSESSIONCONTROL (&IID_IAudioSessionControl)
+#define IID_IAUDIORENDERCLIENT (&IID_IAudioRenderClient)
+#define IID_IMMDEVICEENUMERATOR (&IID_IMMDeviceEnumerator)
+#define IID_IAUDIOCAPTURECLIENT (&IID_IAudioCaptureClient)
+#endif
 
 // Attempting to use the Windows-supplied versions of these constants resulted
 // in `undefined reference` linker errors.
@@ -204,8 +287,8 @@ static void from_wave_format_layout(WAVEFORMATEXTENSIBLE *wave_format, struct So
 
 static enum SoundIoFormat from_wave_format_format(WAVEFORMATEXTENSIBLE *wave_format) {
     assert(wave_format->Format.wFormatTag == WAVE_FORMAT_EXTENSIBLE);
-    bool is_pcm = IsEqualGUID(&wave_format->SubFormat, &SOUNDIO_KSDATAFORMAT_SUBTYPE_PCM);
-    bool is_float = IsEqualGUID(&wave_format->SubFormat, &SOUNDIO_KSDATAFORMAT_SUBTYPE_IEEE_FLOAT);
+    bool is_pcm = IS_EQUAL_GUID(&wave_format->SubFormat, &SOUNDIO_KSDATAFORMAT_SUBTYPE_PCM);
+    bool is_float = IS_EQUAL_GUID(&wave_format->SubFormat, &SOUNDIO_KSDATAFORMAT_SUBTYPE_IEEE_FLOAT);
 
     if (wave_format->Samples.wValidBitsPerSample == wave_format->Format.wBitsPerSample) {
         if (wave_format->Format.wBitsPerSample == 8) {
@@ -352,7 +435,7 @@ static double from_reference_time(REFERENCE_TIME rt) {
 }
 
 static REFERENCE_TIME to_reference_time(double seconds) {
-    return seconds * 10000000.0 + 0.5;
+    return (REFERENCE_TIME)(seconds * 10000000.0 + 0.5);
 }
 
 static void destruct_device(struct SoundIoDevicePrivate *dev) {
@@ -707,7 +790,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             IUnknown_Release(rd.audio_client);
             rd.audio_client = NULL;
         }
-        if (FAILED(hr = IMMDevice_Activate(rd.mm_device, &IID_IAudioClient,
+        if (FAILED(hr = IMMDevice_Activate(rd.mm_device, IID_IAUDIOCLIENT,
                         CLSCTX_ALL, NULL, (void**)&rd.audio_client)))
         {
             deinit_refresh_devices(&rd);
@@ -733,7 +816,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             IMMEndpoint_Release(rd.endpoint);
             rd.endpoint = NULL;
         }
-        if (FAILED(hr = IMMDevice_QueryInterface(rd.mm_device, &IID_IMMEndpoint, (void**)&rd.endpoint))) {
+        if (FAILED(hr = IMMDevice_QueryInterface(rd.mm_device, IID_IMMENDPOINT, (void**)&rd.endpoint))) {
             deinit_refresh_devices(&rd);
             return SoundIoErrorOpeningDevice;
         }
@@ -763,7 +846,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
         PropVariantInit(&rd.prop_variant_value);
         rd.prop_variant_value_inited = true;
         if (FAILED(hr = IPropertyStore_GetValue(rd.prop_store,
-                        &PKEY_Device_FriendlyName, &rd.prop_variant_value)))
+                        PKEY_DEVICE_FRIENDLYNAME, &rd.prop_variant_value)))
         {
             deinit_refresh_devices(&rd);
             return SoundIoErrorOpeningDevice;
@@ -793,7 +876,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
         }
         PropVariantInit(&rd.prop_variant_value);
         rd.prop_variant_value_inited = true;
-        if (FAILED(hr = IPropertyStore_GetValue(rd.prop_store, &PKEY_AudioEngine_DeviceFormat,
+        if (FAILED(hr = IPropertyStore_GetValue(rd.prop_store, PKEY_AUDIOENGINE_DEVICEFORMAT,
                         &rd.prop_variant_value)))
         {
             deinit_refresh_devices(&rd);
@@ -839,9 +922,9 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             // Let's pick some reasonable min and max values.
             rd.device_shared->sample_rate_count = 1;
             rd.device_shared->sample_rates = &dev_shared->prealloc_sample_rate_range;
-            rd.device_shared->sample_rates[0].min = min(SOUNDIO_MIN_SAMPLE_RATE,
+            rd.device_shared->sample_rates[0].min = soundio_int_min(SOUNDIO_MIN_SAMPLE_RATE,
                     rd.device_shared->sample_rate_current);
-            rd.device_shared->sample_rates[0].max = max(SOUNDIO_MAX_SAMPLE_RATE,
+            rd.device_shared->sample_rates[0].max = soundio_int_max(SOUNDIO_MAX_SAMPLE_RATE,
                     rd.device_shared->sample_rate_current);
         } else {
             // Shared mode input stream: mix format is all we can do.
@@ -935,8 +1018,8 @@ static void device_thread_run(void *arg) {
     struct SoundIoWasapi *siw = &si->backend_data.wasapi;
     int err;
 
-    HRESULT hr = CoCreateInstance(&CLSID_MMDeviceEnumerator, NULL,
-            CLSCTX_ALL, &IID_IMMDeviceEnumerator, (void**)&siw->device_enumerator);
+    HRESULT hr = CoCreateInstance(CLSID_MMDEVICEENUMERATOR, NULL,
+            CLSCTX_ALL, IID_IMMDEVICEENUMERATOR, (void**)&siw->device_enumerator);
     if (FAILED(hr)) {
         shutdown_backend(si, SoundIoErrorSystemResources);
         return;
@@ -1088,7 +1171,7 @@ static int outstream_do_open(struct SoundIoPrivate *si, struct SoundIoOutStreamP
     struct SoundIoDeviceWasapi *dw = &dev->backend_data.wasapi;
     HRESULT hr;
 
-    if (FAILED(hr = IMMDevice_Activate(dw->mm_device, &IID_IAudioClient,
+    if (FAILED(hr = IMMDevice_Activate(dw->mm_device, IID_IAUDIOCLIENT,
                     CLSCTX_ALL, NULL, (void**)&osw->audio_client)))
     {
         return SoundIoErrorOpeningDevice;
@@ -1135,7 +1218,7 @@ static int outstream_do_open(struct SoundIoPrivate *si, struct SoundIoOutStreamP
             }
             IUnknown_Release(osw->audio_client);
             osw->audio_client = NULL;
-            if (FAILED(hr = IMMDevice_Activate(dw->mm_device, &IID_IAudioClient,
+            if (FAILED(hr = IMMDevice_Activate(dw->mm_device, IID_IAUDIOCLIENT,
                             CLSCTX_ALL, NULL, (void**)&osw->audio_client)))
             {
                 return SoundIoErrorOpeningDevice;
@@ -1195,7 +1278,7 @@ static int outstream_do_open(struct SoundIoPrivate *si, struct SoundIoOutStreamP
             return SoundIoErrorOpeningDevice;
         }
     } else if (osw->need_resample) {
-        if (FAILED(hr = IAudioClient_GetService(osw->audio_client, &IID_IAudioClockAdjustment,
+        if (FAILED(hr = IAudioClient_GetService(osw->audio_client, IID_IAUDIOCLOCKADJUSTMENT,
                         (void**)&osw->audio_clock_adjustment)))
         {
             return SoundIoErrorOpeningDevice;
@@ -1208,7 +1291,7 @@ static int outstream_do_open(struct SoundIoPrivate *si, struct SoundIoOutStreamP
     }
 
     if (outstream->name) {
-        if (FAILED(hr = IAudioClient_GetService(osw->audio_client, &IID_IAudioSessionControl,
+        if (FAILED(hr = IAudioClient_GetService(osw->audio_client, IID_IAUDIOSESSIONCONTROL,
                         (void **)&osw->audio_session_control)))
         {
             return SoundIoErrorOpeningDevice;
@@ -1225,7 +1308,7 @@ static int outstream_do_open(struct SoundIoPrivate *si, struct SoundIoOutStreamP
         }
     }
 
-    if (FAILED(hr = IAudioClient_GetService(osw->audio_client, &IID_IAudioRenderClient,
+    if (FAILED(hr = IAudioClient_GetService(osw->audio_client, IID_IAUDIORENDERCLIENT,
                     (void **)&osw->audio_render_client)))
     {
         return SoundIoErrorOpeningDevice;
@@ -1250,7 +1333,7 @@ static void outstream_shared_run(struct SoundIoOutStreamPrivate *os) {
         outstream->error_callback(outstream, SoundIoErrorStreaming);
         return;
     }
-    int frame_count_min = max(0, (int)osw->min_padding_frames - (int)frames_used);
+    int frame_count_min = soundio_int_max(0, (int)osw->min_padding_frames - (int)frames_used);
     outstream->write_callback(outstream, frame_count_min, osw->writable_frame_count);
 
     if (FAILED(hr = IAudioClient_Start(osw->audio_client))) {
@@ -1314,7 +1397,7 @@ static void outstream_shared_run(struct SoundIoOutStreamPrivate *os) {
         if (osw->writable_frame_count > 0) {
             if (frames_used == 0 && !reset_buffer)
                 outstream->underflow_callback(outstream);
-            int frame_count_min = max(0, (int)osw->min_padding_frames - (int)frames_used);
+            int frame_count_min = soundio_int_max(0, (int)osw->min_padding_frames - (int)frames_used);
             outstream->write_callback(outstream, frame_count_min, osw->writable_frame_count);
         }
     }
@@ -1609,7 +1692,7 @@ static int instream_do_open(struct SoundIoPrivate *si, struct SoundIoInStreamPri
     struct SoundIoDeviceWasapi *dw = &dev->backend_data.wasapi;
     HRESULT hr;
 
-    if (FAILED(hr = IMMDevice_Activate(dw->mm_device, &IID_IAudioClient,
+    if (FAILED(hr = IMMDevice_Activate(dw->mm_device, IID_IAUDIOCLIENT,
                     CLSCTX_ALL, NULL, (void**)&isw->audio_client)))
     {
         return SoundIoErrorOpeningDevice;
@@ -1657,7 +1740,7 @@ static int instream_do_open(struct SoundIoPrivate *si, struct SoundIoInStreamPri
             }
             IUnknown_Release(isw->audio_client);
             isw->audio_client = NULL;
-            if (FAILED(hr = IMMDevice_Activate(dw->mm_device, &IID_IAudioClient,
+            if (FAILED(hr = IMMDevice_Activate(dw->mm_device, IID_IAUDIOCLIENT,
                             CLSCTX_ALL, NULL, (void**)&isw->audio_client)))
             {
                 return SoundIoErrorOpeningDevice;
@@ -1711,7 +1794,7 @@ static int instream_do_open(struct SoundIoPrivate *si, struct SoundIoInStreamPri
     }
 
     if (instream->name) {
-        if (FAILED(hr = IAudioClient_GetService(isw->audio_client, &IID_IAudioSessionControl,
+        if (FAILED(hr = IAudioClient_GetService(isw->audio_client, IID_IAUDIOSESSIONCONTROL,
                         (void **)&isw->audio_session_control)))
         {
             return SoundIoErrorOpeningDevice;
@@ -1728,7 +1811,7 @@ static int instream_do_open(struct SoundIoPrivate *si, struct SoundIoInStreamPri
         }
     }
 
-    if (FAILED(hr = IAudioClient_GetService(isw->audio_client, &IID_IAudioCaptureClient,
+    if (FAILED(hr = IAudioClient_GetService(isw->audio_client, IID_IAUDIOCAPTURECLIENT,
                     (void **)&isw->audio_capture_client)))
     {
         return SoundIoErrorOpeningDevice;
@@ -1938,7 +2021,7 @@ static int instream_begin_read_wasapi(struct SoundIoPrivate *si, struct SoundIoI
             isw->read_buf = NULL;
     }
 
-    isw->read_frame_count = min(*frame_count, isw->read_buf_frames_left);
+    isw->read_frame_count = soundio_int_min(*frame_count, isw->read_buf_frames_left);
     *frame_count = isw->read_frame_count;
 
     if (isw->read_buf) {
@@ -2017,7 +2100,7 @@ static inline struct SoundIoPrivate *soundio_MMNotificationClient_si(IMMNotifica
 static STDMETHODIMP soundio_MMNotificationClient_QueryInterface(IMMNotificationClient *client,
         REFIID riid, void **ppv)
 {
-    if (IsEqualIID(riid, &IID_IUnknown) || IsEqualIID(riid, &IID_IMMNotificationClient)) {
+    if (IS_EQUAL_IID(riid, &IID_IUnknown) || IS_EQUAL_IID(riid, &IID_IMMNotificationClient)) {
         *ppv = client;
         IUnknown_AddRef(client);
         return S_OK;

--- a/src/wasapi.h
+++ b/src/wasapi.h
@@ -13,14 +13,13 @@
 #include "list.h"
 #include "atomics.h"
 
-#define INITGUID
 #define CINTERFACE
 #define COBJMACROS
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <mmdeviceapi.h>
-#include <functiondiscoverykeys_devpkey.h>
-#include <mmreg.h>
 #include <audioclient.h>
 #include <audiosessiontypes.h>
 #include <audiopolicy.h>

--- a/src/wasapi.h
+++ b/src/wasapi.h
@@ -63,15 +63,15 @@ struct SoundIoOutStreamWasapi {
     struct SoundIoOsMutex *mutex;
     struct SoundIoOsCond *cond;
     struct SoundIoOsCond *start_cond;
-    atomic_flag thread_exit_flag;
+    struct SoundIoAtomicFlag thread_exit_flag;
     bool is_raw;
     int writable_frame_count;
     UINT32 buffer_frame_count;
     int write_frame_count;
     HANDLE h_event;
     struct SoundIoAtomicBool desired_pause_state;
-    atomic_flag pause_resume_flag;
-    atomic_flag clear_buffer_flag;
+    struct SoundIoAtomicFlag pause_resume_flag;
+    struct SoundIoAtomicFlag clear_buffer_flag;
     bool is_paused;
     bool open_complete;
     int open_err;
@@ -89,7 +89,7 @@ struct SoundIoInStreamWasapi {
     struct SoundIoOsMutex *mutex;
     struct SoundIoOsCond *cond;
     struct SoundIoOsCond *start_cond;
-    atomic_flag thread_exit_flag;
+    struct SoundIoAtomicFlag thread_exit_flag;
     bool is_raw;
     int readable_frame_count;
     UINT32 buffer_frame_count;


### PR DESCRIPTION
I wrapped atomic_flag (as done for other atomic types) and added a cast in the ALLOCATE_ macros.
This is a first step towards #49 