### PR TITLE
Handle ALSA devices with null description

### DIFF
--- a/src/alsa.c
+++ b/src/alsa.c
@@ -79,6 +79,8 @@ static inline snd_pcm_uframes_t ceil_dbl_to_uframes(double x) {
 }
 
 static char * str_partition_on_char(char *str, char c) {
+    if (!str)
+        return NULL;
     while (*str) {
         if (*str == c) {
             *str = 0;
@@ -573,7 +575,8 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             device->is_raw = false;
             device->id = strdup(name);
             device->name = descr1 ?
-                soundio_alloc_sprintf(NULL, "%s: %s", descr, descr1) : strdup(descr);
+                soundio_alloc_sprintf(NULL, "%s: %s", descr, descr1) : descr ?
+                strdup(descr) : strdup(name);
 
             if (!device->id || !device->name) {
                 soundio_device_unref(device);


### PR DESCRIPTION
I was seeing some segfaults which were happening when processing a device that seemed to have no description, so the descr1 variable was null. The device in question was produced by /usr/share/alsa/alsa.conf.d/equal.conf from the libasound2-plugin-equal package on debian, which contained the following:
```
ctl.equal {
  type equal;
}

pcm.equal {
  type equal;
}
```
Removing that alsa conf file or patching to check for the null values fixed the issue for me. This patch falls back to using the device ID ("equal" in this case) when there is no description.