### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+dist: trusty
+before_install:
+ - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+ - sudo apt-get update -q
+ - sudo apt-get install g++-4.9 cmake libasound2-dev -y
+ - export CXX="g++-4.9" CC="gcc-4.9"
+script:
+ - mkdir build
+ - cd build
+ - cmake ..
+ - make
+ - sudo make install


### PR DESCRIPTION
Add configuration for Travis continuous integration tests to check that the current commit is building successfully. Test is configured to run against Ubuntu 14 Trusty. (This is what notified me about the recent build issue.)

Demonstrated here, passing against a current fork:

https://travis-ci.org/ideoforms/libsoundio

Needs to be configured on https://travis-ci.org/ to run automatically on each push.

Unfortunately, the unit tests won't pass as the Ubuntu virtual machine doesn't have a default audio output device, so it's simply configured to check the build status right now.