### PR TITLE
Travis: Add travis_retry to make apt-get commands persistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: trusty
 before_install:
  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
- - sudo apt-get update -q
- - sudo apt-get install g++-4.9 cmake libasound2-dev -y
+ - travis_retry sudo apt-get update -q
+ - travis_retry sudo apt-get install g++-4.9 cmake libasound2-dev -y
  - export CXX="g++-4.9" CC="gcc-4.9"
 script:
  - mkdir build


### PR DESCRIPTION
To resolve transient connectivity problems as encountered here: https://github.com/andrewrk/libsoundio/pull/71#issuecomment-215042696