### PR TITLE
WASAPI: define WIN32_LEAN_AND_MEAN in source as well as header

### DIFF
--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -5,6 +5,10 @@
  * See http://opensource.org/licenses/MIT
  */
 
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
 #define INITGUID
 #define CINTERFACE
 #define COBJMACROS


### PR DESCRIPTION
When compiling with Visual Studio (#49), prevents this error:

```
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.10586.0\um\commdlg.h(929): error C2373: 'IPrintDialogCallbackVtbl': redefinition; different type modifiers
1>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10586.0\um\commdlg.h(929): note: see declaration of 'IPrintDialogCallbackVtbl'
1>C:\Program Files (x86)\Windows Kits\10\Include\10.0.10586.0\um\commdlg.h(961): error C2373: 'IPrintDialogServicesVtbl': redefinition; different type modifiers
1>  C:\Program Files (x86)\Windows Kits\10\Include\10.0.10586.0\um\commdlg.h(961): note: see declaration of 'IPrintDialogServicesVtbl'
```

![ryan reynolds but why - imgur](https://cloud.githubusercontent.com/assets/594093/15524424/1dac19fa-21d7-11e6-9b65-1c7602f42724.gif)
