### PR TITLE
WASAPI: Correctly handle no input or output devices instead of crashing.

### DIFF
--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -25,6 +25,9 @@
 
 #include <stdio.h>
 
+// Some HRESULT values are not defined by the windows headers
+#define E_NOTFOUND 0x80070490
+
 #ifdef __cplusplus
 // In C++ mode, IsEqualGUID() takes its arguments by reference
 #define IS_EQUAL_GUID(a, b) IsEqualGUID(*(a), *(b))

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -666,40 +666,48 @@ static int refresh_devices(struct SoundIoPrivate *si) {
     if (FAILED(hr = IMMDeviceEnumerator_GetDefaultAudioEndpoint(siw->device_enumerator, eRender,
                     eMultimedia, &rd.default_render_device)))
     {
-        deinit_refresh_devices(&rd);
-        return SoundIoErrorOpeningDevice;
+        if(hr != E_NOTFOUND) {
+            deinit_refresh_devices(&rd);
+            return SoundIoErrorOpeningDevice;
+        }
     }
-    if (rd.lpwstr) {
-        CoTaskMemFree(rd.lpwstr);
-        rd.lpwstr = NULL;
-    }
-    if (FAILED(hr = IMMDevice_GetId(rd.default_render_device, &rd.lpwstr))) {
-        deinit_refresh_devices(&rd);
-        return SoundIoErrorOpeningDevice;
-    }
-    if ((err = from_lpwstr(rd.lpwstr, &rd.default_render_id, &rd.default_render_id_len))) {
-        deinit_refresh_devices(&rd);
-        return err;
+    if(rd.default_render_device) {
+        if (rd.lpwstr) {
+            CoTaskMemFree(rd.lpwstr);
+            rd.lpwstr = NULL;
+        }
+        if (FAILED(hr = IMMDevice_GetId(rd.default_render_device, &rd.lpwstr))) {
+            deinit_refresh_devices(&rd);
+            return SoundIoErrorOpeningDevice;
+        }
+        if ((err = from_lpwstr(rd.lpwstr, &rd.default_render_id, &rd.default_render_id_len))) {
+            deinit_refresh_devices(&rd);
+            return err;
+        }
     }
 
 
     if (FAILED(hr = IMMDeviceEnumerator_GetDefaultAudioEndpoint(siw->device_enumerator, eCapture,
                     eMultimedia, &rd.default_capture_device)))
     {
-        deinit_refresh_devices(&rd);
-        return SoundIoErrorOpeningDevice;
+        if(hr != E_NOTFOUND) {
+            deinit_refresh_devices(&rd);
+            return SoundIoErrorOpeningDevice;
+        }
     }
-    if (rd.lpwstr) {
-        CoTaskMemFree(rd.lpwstr);
-        rd.lpwstr = NULL;
-    }
-    if (FAILED(hr = IMMDevice_GetId(rd.default_capture_device, &rd.lpwstr))) {
-        deinit_refresh_devices(&rd);
-        return SoundIoErrorOpeningDevice;
-    }
-    if ((err = from_lpwstr(rd.lpwstr, &rd.default_capture_id, &rd.default_capture_id_len))) {
-        deinit_refresh_devices(&rd);
-        return err;
+    if(rd.default_capture_device) {
+        if (rd.lpwstr) {
+            CoTaskMemFree(rd.lpwstr);
+            rd.lpwstr = NULL;
+        }
+        if (FAILED(hr = IMMDevice_GetId(rd.default_capture_device, &rd.lpwstr))) {
+            deinit_refresh_devices(&rd);
+            return SoundIoErrorOpeningDevice;
+        }
+        if ((err = from_lpwstr(rd.lpwstr, &rd.default_capture_id, &rd.default_capture_id_len))) {
+            deinit_refresh_devices(&rd);
+            return err;
+        }
     }
 
 

--- a/src/wasapi.h
+++ b/src/wasapi.h
@@ -24,6 +24,8 @@
 #include <audiosessiontypes.h>
 #include <audiopolicy.h>
 
+#define E_NOTFOUND 0x80070490
+
 struct SoundIoPrivate;
 int soundio_wasapi_init(struct SoundIoPrivate *si);
 

--- a/src/wasapi.h
+++ b/src/wasapi.h
@@ -24,8 +24,6 @@
 #include <audiosessiontypes.h>
 #include <audiopolicy.h>
 
-#define E_NOTFOUND 0x80070490
-
 struct SoundIoPrivate;
 int soundio_wasapi_init(struct SoundIoPrivate *si);
 


### PR DESCRIPTION
Should fix #63 

I wasn't sure where to put the error define, but the other definitions are in the header so I just threw it in there.