### PR TITLE
Static lib and dynamic lib building options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ set(LIBSOUNDIO_VERSION_PATCH 0)
 set(LIBSOUNDIO_VERSION "${LIBSOUNDIO_VERSION_MAJOR}.${LIBSOUNDIO_VERSION_MINOR}.${LIBSOUNDIO_VERSION_PATCH}")
 message("Configuring libsoundio version ${LIBSOUNDIO_VERSION}")
 
+if(NOT SOUNDIO_STATIC_LIBNAME)
+    set(SOUNDIO_STATIC_LIBNAME soundio)
+endif()
+
 option(BUILD_STATIC_LIBS "Build static libraries" ON)
 option(BUILD_EXAMPLE_PROGRAMS "Build example programs" ON)
 option(BUILD_TESTS "Build tests" ON)
@@ -233,7 +237,7 @@ install(TARGETS libsoundio_shared DESTINATION ${CMAKE_INSTALL_LIBDIR})
 if(BUILD_STATIC_LIBS)
     add_library(libsoundio_static STATIC ${LIBSOUNDIO_SOURCES})
     set_target_properties(libsoundio_static PROPERTIES
-        OUTPUT_NAME soundio
+        OUTPUT_NAME ${SOUNDIO_STATIC_LIBNAME}
         COMPILE_FLAGS ${LIB_CFLAGS}
         LINKER_LANGUAGE C
     )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ if(NOT SOUNDIO_STATIC_LIBNAME)
 endif()
 
 option(BUILD_STATIC_LIBS "Build static libraries" ON)
+option(BUILD_DYNAMIC_LIBS "Build dynamic libraries" ON)
 option(BUILD_EXAMPLE_PROGRAMS "Build example programs" ON)
 option(BUILD_TESTS "Build tests" ON)
 option(ENABLE_JACK "Enable JACK backend" ON)
@@ -222,17 +223,18 @@ configure_file(
     ${DOXYGEN_CONF_FILE}
 )
 
-add_library(libsoundio_shared SHARED ${LIBSOUNDIO_SOURCES})
-set_target_properties(libsoundio_shared PROPERTIES
-    OUTPUT_NAME soundio
-    SOVERSION ${LIBSOUNDIO_VERSION_MAJOR}
-    VERSION ${LIBSOUNDIO_VERSION}
-    COMPILE_FLAGS ${LIB_CFLAGS}
-    LINKER_LANGUAGE C
-)
-target_link_libraries(libsoundio_shared LINK_PUBLIC ${LIBSOUNDIO_LIBS})
-install(TARGETS libsoundio_shared DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
+if(BUILD_DYNAMIC_LIBS)
+    add_library(libsoundio_shared SHARED ${LIBSOUNDIO_SOURCES})
+    set_target_properties(libsoundio_shared PROPERTIES
+        OUTPUT_NAME soundio
+        SOVERSION ${LIBSOUNDIO_VERSION_MAJOR}
+        VERSION ${LIBSOUNDIO_VERSION}
+        COMPILE_FLAGS ${LIB_CFLAGS}
+        LINKER_LANGUAGE C
+    )
+    target_link_libraries(libsoundio_shared LINK_PUBLIC ${LIBSOUNDIO_LIBS})
+    install(TARGETS libsoundio_shared DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
 
 if(BUILD_STATIC_LIBS)
     add_library(libsoundio_static STATIC ${LIBSOUNDIO_SOURCES})


### PR DESCRIPTION
Hello, I have returned with another set of minor changes to the cmake file.
Today I propose, `BUILD_DYNAMIC_LIBS` and `SOUNDIO_STATIC_LIBNAME`.

`BUILD_DYNAMIC_LIBS`, allows users to opt in for building the dynamic lib (.so, .dylib, .dll or whatever platforms do these days), it defaults to ON by default, so no one will feel any disturbances (hopefully)

The second option is `SOUNDIO_STATIC_LIBNAME`, since the output for both the static and dynamic libs have the same basename (libsoundio.(a|so)), it can cause some issues with compilers who refuse to be nice and just link the static object first, while this can be alleviated by simply specifying the full path to the static lib in question, in some cases it's out of the question where the compilation process is handled by something else which only offers you the ability link libraries (by name).

tl;dr I can haz `libsoundio_static.a` instead of `libsoundio.a`, to help ease the pain, because no one likes monkeying around their compiler for hours