### PR TITLE
Only define E_NOTFOUND if not already defined

### DIFF
--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -26,7 +26,9 @@
 #include <stdio.h>
 
 // Some HRESULT values are not defined by the windows headers
+#ifndef E_NOTFOUND
 #define E_NOTFOUND 0x80070490
+#endif //E_NOTFOUND
 
 #ifdef __cplusplus
 // In C++ mode, IsEqualGUID() takes its arguments by reference


### PR DESCRIPTION
Hey, i got an error while trying to compile libsoundio using mingw64 (and cmake and ninja), without using any additional cmake options:

``````````````
../src/wasapi.c:29:0: error: "E_NOTFOUND" redefined [-Werror]
 #define E_NOTFOUND 0x80070490
 ^
In file included from C:/msys64/mingw64/x86_64-w64-mingw32/include/endpointvolume.h:38:0,
                 from ../src/wasapi.c:18:
C:/msys64/mingw64/x86_64-w64-mingw32/include/devicetopology.h:185:0: note: this is the location of the previous definition
 #define E_NOTFOUND HRESULT_FROM_WIN32(ERROR_NOT_FOUND)
 ^
cc1.exe: all warnings being treated as errors
```````````````````

It seems like E_NOTFOUND is already defined in some cases which causes a compile error.
Fixed that by simply checking if it is already defined before manually defining it in wasapi.c.