### PR TITLE
WASAPI: Remove useless statement in CMake module

### DIFF
--- a/cmake/FindWASAPI.cmake
+++ b/cmake/FindWASAPI.cmake
@@ -5,11 +5,10 @@
 # WASAPI_FOUND
 # AUDIOCLIENT_H
 
-if (WIN32)
-  include(CheckIncludeFile)
-  check_include_file(audioclient.h AUDIOCLIENT_H)
+if(WIN32)
+    include(CheckIncludeFile)
+    check_include_file(audioclient.h AUDIOCLIENT_H)
 endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(WASAPI DEFAULT_MSG AUDIOCLIENT_H)
-mark_as_advanced(AUDIOCLIENT_H)


### PR DESCRIPTION
AUDIOCLIENT_H, as declared here, is not an external cached variable, so calling mark_as_advanced() has no apparent effect (does not enable user to modify value, even in advanced mode). Even if it were cached, its value (success/failure at finding audioclient.h) should not be edited by the user.

Also modified whitespace to be more consistent with that found in CMakeLists.txt.
