### PR TITLE
WASAPI device error handling

### DIFF
--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -716,7 +716,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             if(hr == E_OUTOFMEMORY) {
                 return SoundIoErrorNoMem;
             }
-            return SoundIoErrorNoMem;
+            return SoundIoErrorOpeningDevice;
         }
         if ((err = from_lpwstr(rd.lpwstr, &rd.default_capture_id, &rd.default_capture_id_len))) {
             deinit_refresh_devices(&rd);

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -713,8 +713,9 @@ static int refresh_devices(struct SoundIoPrivate *si) {
         }
         if (FAILED(hr = IMMDevice_GetId(rd.default_capture_device, &rd.lpwstr))) {
             deinit_refresh_devices(&rd);
-            // MSDN states the IMMDevice_GetId can fail if the device is NULL, or if we're out of memory
-            // We know the device point isn't NULL so we're necessarily out of memory.
+            if(hr == E_OUTOFMEMORY) {
+                return SoundIoErrorNoMem;
+            }
             return SoundIoErrorNoMem;
         }
         if ((err = from_lpwstr(rd.lpwstr, &rd.default_capture_id, &rd.default_capture_id_len))) {
@@ -932,8 +933,8 @@ static int refresh_devices(struct SoundIoPrivate *si) {
         }
         int device_name_len;
         if ((err = from_lpwstr(rd.prop_variant_value.pwszVal, &rd.device_shared->name, &device_name_len))) {
-            rd.device_shared->probe_error = SoundIoErrorOpeningDevice;
-            rd.device_raw->probe_error = SoundIoErrorOpeningDevice;
+            rd.device_shared->probe_error = err;
+            rd.device_raw->probe_error = err;
             rd.device_shared = NULL;
             rd.device_raw = NULL;
             continue;
@@ -974,19 +975,19 @@ static int refresh_devices(struct SoundIoPrivate *si) {
         if ((err = detect_valid_sample_rates(&rd, valid_wave_format, dev_raw,
                         AUDCLNT_SHAREMODE_EXCLUSIVE)))
         {
-            rd.device_raw->probe_error = SoundIoErrorOpeningDevice;
+            rd.device_raw->probe_error = err;
             rd.device_raw = NULL;
         }
         if (rd.device_raw && (err = detect_valid_formats(&rd, valid_wave_format, dev_raw,
                         AUDCLNT_SHAREMODE_EXCLUSIVE)))
         {
-            rd.device_raw->probe_error = SoundIoErrorOpeningDevice;
+            rd.device_raw->probe_error = err;
             rd.device_raw = NULL;
         }
         if (rd.device_raw && (err = detect_valid_layouts(&rd, valid_wave_format, dev_raw,
             AUDCLNT_SHAREMODE_EXCLUSIVE)))
         {
-            rd.device_raw->probe_error = SoundIoErrorOpeningDevice;
+            rd.device_raw->probe_error = err;
             rd.device_raw = NULL;
         }
 
@@ -1030,7 +1031,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             if ((err = detect_valid_formats(&rd, rd.wave_format, dev_shared,
                 AUDCLNT_SHAREMODE_SHARED)))
             {
-                rd.device_shared->probe_error = SoundIoErrorOpeningDevice;
+                rd.device_shared->probe_error = err;
                 rd.device_shared = NULL;
             }
             else {

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -671,6 +671,9 @@ static int refresh_devices(struct SoundIoPrivate *si) {
     {
         if(hr != E_NOTFOUND) {
             deinit_refresh_devices(&rd);
+            if(hr == E_OUTOFMEMORY) {
+                return SoundIoErrorNoMem;
+            }
             return SoundIoErrorOpeningDevice;
         }
     }
@@ -681,7 +684,9 @@ static int refresh_devices(struct SoundIoPrivate *si) {
         }
         if (FAILED(hr = IMMDevice_GetId(rd.default_render_device, &rd.lpwstr))) {
             deinit_refresh_devices(&rd);
-            return SoundIoErrorOpeningDevice;
+            // MSDN states the IMMDevice_GetId can fail if the device is NULL, or if we're out of memory
+            // We know the device point isn't NULL so we're necessarily out of memory
+            return SoundIoErrorNoMem;
         }
         if ((err = from_lpwstr(rd.lpwstr, &rd.default_render_id, &rd.default_render_id_len))) {
             deinit_refresh_devices(&rd);
@@ -695,6 +700,9 @@ static int refresh_devices(struct SoundIoPrivate *si) {
     {
         if(hr != E_NOTFOUND) {
             deinit_refresh_devices(&rd);
+            if(hr == E_OUTOFMEMORY) {
+                return SoundIoErrorNoMem;
+            }
             return SoundIoErrorOpeningDevice;
         }
     }
@@ -705,7 +713,9 @@ static int refresh_devices(struct SoundIoPrivate *si) {
         }
         if (FAILED(hr = IMMDevice_GetId(rd.default_capture_device, &rd.lpwstr))) {
             deinit_refresh_devices(&rd);
-            return SoundIoErrorOpeningDevice;
+            // MSDN states the IMMDevice_GetId can fail if the device is NULL, or if we're out of memory
+            // We know the device point isn't NULL so we're necessarily out of memory.
+            return SoundIoErrorNoMem;
         }
         if ((err = from_lpwstr(rd.lpwstr, &rd.default_capture_id, &rd.default_capture_id_len))) {
             deinit_refresh_devices(&rd);
@@ -718,11 +728,16 @@ static int refresh_devices(struct SoundIoPrivate *si) {
                     eAll, DEVICE_STATE_ACTIVE, &rd.collection)))
     {
         deinit_refresh_devices(&rd);
+        if(hr == E_OUTOFMEMORY) {
+            return SoundIoErrorNoMem;
+        }
         return SoundIoErrorOpeningDevice;
     }
 
     UINT unsigned_count;
     if (FAILED(hr = IMMDeviceCollection_GetCount(rd.collection, &unsigned_count))) {
+        // In theory this shouldn't happen since the only documented failure case is that
+        // rd.collection is NULL, but then EnumAudioEndpoints should have failed.
         deinit_refresh_devices(&rd);
         return SoundIoErrorOpeningDevice;
     }


### PR DESCRIPTION
This is intended to fix #80, from the very-small-scale testing I've done (my own machine and 2 others) it appears to work. I'll continue to check up as I get to test on more machines.

I've basically just made it flag the device and move on when it encounters an error. For reference if you want to reproduce this, you can go to the settings of one of your audio devices in Windows and uncheck the "Allow applications to take exclusive control of this device" (at least thats what its called on Windows 7, under Advanced in device properties). With that unchecked WASAPI disconnects immediately without this fix, but now it just flags the raw device and moves on (letting you open the shared device).