### PR TITLE
build: fix detection of unsuitable JACK library

### DIFF
--- a/cmake/FindJACK.cmake
+++ b/cmake/FindJACK.cmake
@@ -10,7 +10,10 @@ find_path(JACK_INCLUDE_DIR NAMES jack/jack.h)
 
 find_library(JACK_LIBRARY NAMES jack)
 
+include(CheckLibraryExists)
+check_library_exists(jack "jack_set_port_rename_callback" "${JACK_LIBRARY}" HAVE_jack_set_port_rename_callback)
+
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(JACK DEFAULT_MSG JACK_LIBRARY JACK_INCLUDE_DIR)
+find_package_handle_standard_args(JACK DEFAULT_MSG JACK_LIBRARY JACK_INCLUDE_DIR HAVE_jack_set_port_rename_callback)
 
 mark_as_advanced(JACK_INCLUDE_DIR JACK_LIBRARY)


### PR DESCRIPTION
I've just taken and applied the patch from https://github.com/andrewrk/libsoundio/issues/122

This resolves https://github.com/andrewrk/libsoundio/issues/11 and https://github.com/andrewrk/libsoundio/issues/35.

I can't repro and test this personally, but I had multiple users run into this issue who linked me this patch.