### PR TITLE
Fix 24-bit playback for macOS

### DIFF
--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -940,6 +940,10 @@ static int set_ca_desc(enum SoundIoFormat fmt, AudioStreamBasicDescription *desc
         desc->mFormatFlags = kAudioFormatFlagIsSignedInteger;
         desc->mBitsPerChannel = 16;
         break;
+	case SoundIoFormatS24LE:
+		desc->mFormatFlags = kAudioFormatFlagIsSignedInteger;
+		desc->mBitsPerChannel = 24;
+		break;
     default:
         return SoundIoErrorIncompatibleDevice;
     }


### PR DESCRIPTION
24 bit playback on OS X uses a 32-bit integer format, with the 3 low bytes containing the sample. This patch adds the correct AudioStreamBasicDescription for this format.