### PR TITLE
Add hardware volume control support to Core Audio and WASAPI backends

### DIFF
--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -536,7 +536,8 @@ struct SoundIoOutStream {
     /// For JACK, this value is always equal to
     /// SoundIoDevice::software_latency_current of the device.
     double software_latency;
-
+    /// Core Audio and WASAPI only: current output Audio Unit volume. Float, 0.0-1.0.
+    float volume;
     /// Defaults to NULL. Put whatever you want here.
     void *userdata;
     /// In this callback, you call ::soundio_outstream_begin_write and
@@ -1056,6 +1057,9 @@ SOUNDIO_EXPORT int soundio_outstream_pause(struct SoundIoOutStream *outstream, b
 /// * #SoundIoErrorStreaming
 SOUNDIO_EXPORT int soundio_outstream_get_latency(struct SoundIoOutStream *outstream,
         double *out_latency);
+
+SOUNDIO_EXPORT int soundio_outstream_set_volume(struct SoundIoOutStream *outstream,
+        double volume);
 
 
 

--- a/src/coreaudio.h
+++ b/src/coreaudio.h
@@ -52,6 +52,7 @@ struct SoundIoOutStreamCoreAudio {
     int frames_left;
     int write_frame_count;
     double hardware_latency;
+    float volume;
     struct SoundIoChannelArea areas[SOUNDIO_MAX_CHANNELS];
 };
 

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -272,6 +272,7 @@ void soundio_disconnect(struct SoundIo *soundio) {
     si->outstream_clear_buffer = NULL;
     si->outstream_pause = NULL;
     si->outstream_get_latency = NULL;
+    si->outstream_set_volume = NULL;
 
     si->instream_open = NULL;
     si->instream_destroy = NULL;
@@ -558,6 +559,13 @@ int soundio_outstream_get_latency(struct SoundIoOutStream *outstream, double *ou
     struct SoundIoPrivate *si = (struct SoundIoPrivate *)soundio;
     struct SoundIoOutStreamPrivate *os = (struct SoundIoOutStreamPrivate *)outstream;
     return si->outstream_get_latency(si, os, out_latency);
+}
+
+int soundio_outstream_set_volume(struct SoundIoOutStream *outstream, double volume) {
+    struct SoundIo *soundio = outstream->device->soundio;
+    struct SoundIoPrivate *si = (struct SoundIoPrivate *)soundio;
+    struct SoundIoOutStreamPrivate *os = (struct SoundIoOutStreamPrivate *)outstream;
+    return si->outstream_set_volume(si, os, volume);
 }
 
 static void default_instream_error_callback(struct SoundIoInStream *is, int err) {

--- a/src/soundio_private.h
+++ b/src/soundio_private.h
@@ -152,7 +152,7 @@ struct SoundIoPrivate {
     int (*outstream_clear_buffer)(struct SoundIoPrivate *, struct SoundIoOutStreamPrivate *);
     int (*outstream_pause)(struct SoundIoPrivate *, struct SoundIoOutStreamPrivate *, bool pause);
     int (*outstream_get_latency)(struct SoundIoPrivate *, struct SoundIoOutStreamPrivate *, double *out_latency);
-
+    int (*outstream_set_volume)(struct SoundIoPrivate *, struct SoundIoOutStreamPrivate *, float volume);
 
     int (*instream_open)(struct SoundIoPrivate *, struct SoundIoInStreamPrivate *);
     void (*instream_destroy)(struct SoundIoPrivate *, struct SoundIoInStreamPrivate *);

--- a/src/wasapi.h
+++ b/src/wasapi.h
@@ -56,6 +56,7 @@ struct SoundIoOutStreamWasapi {
     IAudioClockAdjustment *audio_clock_adjustment;
     IAudioRenderClient *audio_render_client;
     IAudioSessionControl *audio_session_control;
+    ISimpleAudioVolume *audio_volume_control;
     LPWSTR stream_name;
     bool need_resample;
     struct SoundIoOsThread *thread;
@@ -76,6 +77,7 @@ struct SoundIoOutStreamWasapi {
     int open_err;
     bool started;
     UINT32 min_padding_frames;
+    float volume;
     struct SoundIoChannelArea areas[SOUNDIO_MAX_CHANNELS];
 };
 


### PR DESCRIPTION
This patch adds volume control support at the output stream level to the macOS Core Audio and Windows WASAPI backends. It's still technically a software volume control as the device output level is not accessed, rather the stream volume level is set in a range from (float) 0.0 to 1.0, with 1.0 representing unattenuated output.

API is additive only therefore should be source-compatible, although the SoundIoOutStream struct size is changing.

Note the Core Audio patch is fully tested on macOS 10.13 Beta DP5, the WASAPI patch is based on documentation only, and I would appreciate comments from windows users as my Windows-based team is currently out of the office.