### PR TITLE
Fix WASAPI related compile errors

### DIFF
--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -1386,7 +1386,7 @@ static int outstream_do_open(struct SoundIoPrivate *si, struct SoundIoOutStreamP
         return SoundIoErrorOpeningDevice;
     }
 
-    if (FAILED(hr = osw->audio_volume_control->GetMasterVolume(&volume)))
+    if (FAILED(hr = osw->audio_volume_control->lpVtbl->GetMasterVolume(osw->audio_volume_control, &outstream->volume)))
     {
         return SoundIoErrorOpeningDevice;
     }
@@ -1725,7 +1725,7 @@ static int outstream_set_volume_wasapi(struct SoundIoPrivate *si, struct SoundIo
     struct SoundIoOutStreamWasapi *osw = &os->backend_data.wasapi;
 
     HRESULT hr;
-    if (FAILED(hr = osw->audio_volume_control->SetMasterVolume(&volume)))
+    if (FAILED(hr = osw->audio_volume_control->lpVtbl->SetMasterVolume(osw->audio_volume_control, volume, NULL)))
     {
         return SoundIoErrorIncompatibleDevice;
     }


### PR DESCRIPTION
Fixes #167 and #168 and similar compilation errors with latest Windows 10 SDK and Visual Studio 2017.