### PR TITLE
Fix includes for sio_record.c file.

### DIFF
--- a/example/sio_record.c
+++ b/example/sio_record.c
@@ -12,7 +12,11 @@
 #include <string.h>
 #include <math.h>
 #include <errno.h>
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include <unistd.h>
+#endif
 
 struct RecordContext {
     struct SoundIoRingBuffer *ring_buffer;


### PR DESCRIPTION
Addition of static ifs to fix errors within sio_record.c file when working with libsoundio on Windows machine.