### PR TITLE
Fix invalid memory access in soundio_sort_channel_layouts()

### DIFF
--- a/src/soundio.c
+++ b/src/soundio.c
@@ -733,8 +733,8 @@ const struct SoundIoChannelLayout *soundio_best_matching_channel_layout(
 }
 
 static int compare_layouts(const void *a, const void *b) {
-    const struct SoundIoChannelLayout *layout_a = *((struct SoundIoChannelLayout **)a);
-    const struct SoundIoChannelLayout *layout_b = *((struct SoundIoChannelLayout **)b);
+    const struct SoundIoChannelLayout *layout_a = (const struct SoundIoChannelLayout *)a;
+    const struct SoundIoChannelLayout *layout_b = (const struct SoundIoChannelLayout *)b;
     if (layout_a->channel_count > layout_b->channel_count)
         return -1;
     else if (layout_a->channel_count < layout_b->channel_count)


### PR DESCRIPTION
The parameters to `qsort()`'s comparator is a pointer to the items being sorted, not a pointer to a pointer to the items being sorted. As a result of this bug, `soundio_sort_channel_layouts()` doesn't correctly sort layouts and accesses out-of-bounds memory addresses that may cause a crash.