### PR TITLE
Fix improper Unicode CFString conversion in CoreAudio backend

### DIFF
--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -179,7 +179,7 @@ static int from_cf_string(CFStringRef string_ref, char **out_str, int *out_str_l
     assert(string_ref);
 
     CFIndex length = CFStringGetLength(string_ref);
-    CFIndex max_size = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8);
+    CFIndex max_size = CFStringGetMaximumSizeForEncoding(length, kCFStringEncodingUTF8) + 1;
     char *buf = ALLOCATE_NONZERO(char, max_size);
     if (!buf)
         return SoundIoErrorNoMem;


### PR DESCRIPTION
If I change my Mac language to Simplified Chinese, libsoundio stops being able to open any audio devices because `CFStringGetCString()` fails when trying convert the CFString for the audio device name due to not having enough space in the allocated string.

This is because the length that `CFStringGetMaximumSizeForEncoding()` returns does not include the terminating NUL character. It usually works because we don't need the full size that `CFStringGetMaximumSizeForEncoding()` returns for most strings. However, If we really need the worst case number of bytes like we appear to in Simplified Chinese, we'll be a byte short and fail.

Original bug: https://github.com/moonlight-stream/moonlight-qt/issues/104