### PR TITLE
Add missing WASAPI macros for resampling

### DIFF
--- a/src/wasapi.h
+++ b/src/wasapi.h
@@ -24,6 +24,14 @@
 #include <audiosessiontypes.h>
 #include <audiopolicy.h>
 
+#ifndef AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM
+#define AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM 0x80000000
+#endif
+
+#ifndef AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY
+#define AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY 0x08000000
+#endif
+
 struct SoundIoPrivate;
 int soundio_wasapi_init(struct SoundIoPrivate *si);
 


### PR DESCRIPTION
The macros needed to fix #194 are not defined by the MinGW headers (see [here](https://github.com/mirror/mingw-w64/blob/master/mingw-w64-headers/include/audiosessiontypes.h#L51)).