### PR TITLE
Fixed an issue SoundIoOutStream::name is not initialized by default value on some backends

### DIFF
--- a/src/alsa.c
+++ b/src/alsa.c
@@ -1279,6 +1279,9 @@ static int outstream_open_alsa(struct SoundIoPrivate *si, struct SoundIoOutStrea
         outstream->software_latency = 1.0;
     outstream->software_latency = soundio_double_clamp(device->software_latency_min, outstream->software_latency, device->software_latency_max);
 
+    if (!outstream->name)
+        outstream->name = "SoundIoOutStream";
+
     int ch_count = outstream->layout.channel_count;
 
     osa->chmap_size = sizeof(int) + sizeof(int) * ch_count;

--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -960,6 +960,9 @@ static int outstream_open_ca(struct SoundIoPrivate *si, struct SoundIoOutStreamP
     if (outstream->software_latency == 0.0)
         outstream->software_latency = device->software_latency_current;
 
+    if (!outstream->name)
+        outstream->name = "SoundIoOutStream";
+
     outstream->software_latency = soundio_double_clamp(
             device->software_latency_min,
             outstream->software_latency,

--- a/src/dummy.c
+++ b/src/dummy.c
@@ -185,6 +185,9 @@ static int outstream_open_dummy(struct SoundIoPrivate *si, struct SoundIoOutStre
                 device->software_latency_min, 1.0, device->software_latency_max);
     }
 
+    if (!outstream->name)
+        outstream->name = "SoundIoOutStream";
+
     osd->period_duration = outstream->software_latency / 2.0;
 
     int err;

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -1351,23 +1351,26 @@ static int outstream_do_open(struct SoundIoPrivate *si, struct SoundIoOutStreamP
         }
     }
 
-    if (outstream->name) {
-        if (FAILED(hr = IAudioClient_GetService(osw->audio_client, IID_IAUDIOSESSIONCONTROL,
-                        (void **)&osw->audio_session_control)))
-        {
-            return SoundIoErrorOpeningDevice;
-        }
 
-        int err;
-        if ((err = to_lpwstr(outstream->name, strlen(outstream->name), &osw->stream_name))) {
-            return err;
-        }
-        if (FAILED(hr = IAudioSessionControl_SetDisplayName(osw->audio_session_control,
-                        osw->stream_name, NULL)))
-        {
-            return SoundIoErrorOpeningDevice;
-        }
+    if (!outstream->name)
+        outstream->name = "SoundIoOutStream";
+
+    if (FAILED(hr = IAudioClient_GetService(osw->audio_client, IID_IAUDIOSESSIONCONTROL,
+                    (void **)&osw->audio_session_control)))
+    {
+        return SoundIoErrorOpeningDevice;
     }
+
+    int err;
+    if ((err = to_lpwstr(outstream->name, strlen(outstream->name), &osw->stream_name))) {
+        return err;
+    }
+    if (FAILED(hr = IAudioSessionControl_SetDisplayName(osw->audio_session_control,
+                    osw->stream_name, NULL)))
+    {
+        return SoundIoErrorOpeningDevice;
+    }
+
 
     if (FAILED(hr = IAudioClient_GetService(osw->audio_client, IID_IAUDIORENDERCLIENT,
                     (void **)&osw->audio_render_client)))


### PR DESCRIPTION
Even though the document of `SoundIoOutStream::name` says it defaults to `"SoundIoOutStream"`, some backends does not initialize it after `soundio_outstream_open` and leave it `NULL` if user does not provide optional value for it.  

Currently, `JACK` and `PulseAudio` properly initialize it. `Dummy`, `ALSA` and `CoreAudio` don't.  
`WASAPI` also does not initialize it and has null check for it.  

This PR make it always be initialized by default value on all backends.