### PR TITLE
Fix static library exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ if(BUILD_STATIC_LIBS)
     add_library(libsoundio_static STATIC ${LIBSOUNDIO_SOURCES})
     set_target_properties(libsoundio_static PROPERTIES
         OUTPUT_NAME ${SOUNDIO_STATIC_LIBNAME}
-        COMPILE_FLAGS ${LIB_CFLAGS}
+        COMPILE_FLAGS "${LIB_CFLAGS} -DSOUNDIO_STATIC_LIBRARY"
         LINKER_LANGUAGE C
     )
     install(TARGETS libsoundio_static DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
We should use the `SOUNDIO_STATIC_LIBRARY` flag when compiling the static library to prevent any unnecessary exported symbols.