### PR TITLE
Fixed memory leak

### DIFF
--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -486,8 +486,12 @@ static void deinit_refresh_devices(struct RefreshDevices *rd) {
     soundio_device_unref(rd->device_raw);
     if (rd->mm_device)
         IMMDevice_Release(rd->mm_device);
-    if (rd->default_render_device)
-        IMMDevice_Release(rd->default_render_device);
+	if (rd->default_render_device)
+	{
+		IMMDevice_Release(rd->default_render_device);
+		free(rd->default_capture_id);
+		free(rd->default_render_id);
+	}
     if (rd->default_capture_device)
         IMMDevice_Release(rd->default_capture_device);
     if (rd->collection)

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -492,7 +492,10 @@ static void deinit_refresh_devices(struct RefreshDevices *rd) {
 		free(rd->default_render_id);
 	}
     if (rd->default_capture_device)
+    {
         IMMDevice_Release(rd->default_capture_device);
+        free(rd->default_capture_id);
+    }
     if (rd->collection)
         IMMDeviceCollection_Release(rd->collection);
     if (rd->lpwstr)

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -489,7 +489,6 @@ static void deinit_refresh_devices(struct RefreshDevices *rd) {
 	if (rd->default_render_device)
 	{
 		IMMDevice_Release(rd->default_render_device);
-		free(rd->default_capture_id);
 		free(rd->default_render_id);
 	}
     if (rd->default_capture_device)


### PR DESCRIPTION
First of all, thanks for this amazing lib. The API looks amazing!

So I just started testing soundio, but I kept getting a visual leak detection. The leak was caused by `soundio_connect(soundio);`