### PR TITLE
Fix MSVC static library + regular builds via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ if(MSVC)
     set(EXAMPLE_CFLAGS "/W4")
     set(TEST_CFLAGS "${LIB_CFLAGS}")
     set(TEST_LDFLAGS " ")
-    set(LIBM " ")
+    set(LIBM "")
 else()
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror -pedantic")
     set(LIB_CFLAGS "-std=c11 -fvisibility=hidden -Wall -Werror=strict-prototypes -Werror=old-style-definition -Werror=missing-prototypes -D_REENTRANT -D_POSIX_C_SOURCE=200809L -Wno-missing-braces")
@@ -243,6 +243,7 @@ if(BUILD_STATIC_LIBS)
         COMPILE_FLAGS ${LIB_CFLAGS}
         LINKER_LANGUAGE C
     )
+    target_compile_definitions(libsoundio_static PUBLIC SOUNDIO_STATIC_LIBRARY=1)
     install(TARGETS libsoundio_static DESTINATION ${CMAKE_INSTALL_LIBDIR})
 endif()
 


### PR DESCRIPTION
* due to cmake quirks, you can't specify a white-space only library name.  CMake genuinely tries to link a " .lib" resulting in build failures.

* With how the headers are written, if you want to static-link soundio, SOUNDIO_STATIC_LIBRARY must be defined during compile - this suppresses the DLL export/import declarations - if this is not done, you get errors about missing _imp_... symbols during link due to the symbol munging that MSVC uses for DLL import libraries.  Export the symbol through the CMAKE mechanisms by declaring it PUBLIC.