### PR TITLE
Add support for packed 24 bit LE format

### DIFF
--- a/example/sio_microphone.c
+++ b/example/sio_microphone.c
@@ -22,6 +22,7 @@ static enum SoundIoFormat prioritized_formats[] = {
     SoundIoFormatS32FE,
     SoundIoFormatS24NE,
     SoundIoFormatS24FE,
+    SoundIoFormatS24PLE,
     SoundIoFormatS16NE,
     SoundIoFormatS16FE,
     SoundIoFormatFloat64NE,

--- a/example/sio_record.c
+++ b/example/sio_record.c
@@ -24,6 +24,7 @@ static enum SoundIoFormat prioritized_formats[] = {
     SoundIoFormatS32NE,
     SoundIoFormatS32FE,
     SoundIoFormatS24NE,
+    SoundIoFormatS24PLE,
     SoundIoFormatS24FE,
     SoundIoFormatS16NE,
     SoundIoFormatS16FE,

--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -242,6 +242,7 @@ enum SoundIoFormat {
     SoundIoFormatU16BE,     ///< Unsigned 16 bit Big Endian
     SoundIoFormatS24LE,     ///< Signed 24 bit Little Endian using low three bytes in 32-bit word
     SoundIoFormatS24BE,     ///< Signed 24 bit Big Endian using low three bytes in 32-bit word
+    SoundIoFormatS24PLE,    ///< Signed 24 bit Little Endian packed into 3 bytes
     SoundIoFormatU24LE,     ///< Unsigned 24 bit Little Endian using low three bytes in 32-bit word
     SoundIoFormatU24BE,     ///< Unsigned 24 bit Big Endian using low three bytes in 32-bit word
     SoundIoFormatS32LE,     ///< Signed 32 bit Little Endian

--- a/src/alsa.c
+++ b/src/alsa.c
@@ -236,6 +236,7 @@ static snd_pcm_format_t to_alsa_fmt(enum SoundIoFormat fmt) {
     case SoundIoFormatS24BE:        return SND_PCM_FORMAT_S24_BE;
     case SoundIoFormatU24LE:        return SND_PCM_FORMAT_U24_LE;
     case SoundIoFormatU24BE:        return SND_PCM_FORMAT_U24_BE;
+    case SoundIoFormatS24PLE:       return SND_PCM_FORMAT_S24_3LE;
     case SoundIoFormatS32LE:        return SND_PCM_FORMAT_S32_LE;
     case SoundIoFormatS32BE:        return SND_PCM_FORMAT_S32_BE;
     case SoundIoFormatU32LE:        return SND_PCM_FORMAT_U32_LE;
@@ -350,6 +351,7 @@ static int probe_open_device(struct SoundIoDevice *device, snd_pcm_t *handle, in
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_S24_BE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_U24_LE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_U24_BE);
+    snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_S24_3LE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_S32_LE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_S32_BE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_U32_LE);
@@ -364,7 +366,7 @@ static int probe_open_device(struct SoundIoDevice *device, snd_pcm_t *handle, in
 
     if (!device->formats) {
         snd_pcm_hw_params_get_format_mask(hwparams, fmt_mask);
-        device->formats = ALLOCATE(enum SoundIoFormat, 18);
+        device->formats = ALLOCATE(enum SoundIoFormat, 19);
         if (!device->formats)
             return SoundIoErrorNoMem;
 
@@ -379,6 +381,7 @@ static int probe_open_device(struct SoundIoDevice *device, snd_pcm_t *handle, in
         test_fmt_mask(device, fmt_mask, SoundIoFormatS24BE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatU24LE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatU24BE);
+        test_fmt_mask(device, fmt_mask, SoundIoFormatS24PLE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatS32LE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatS32BE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatU32LE);

--- a/src/dummy.c
+++ b/src/dummy.c
@@ -380,7 +380,7 @@ static int instream_get_latency_dummy(struct SoundIoPrivate *si, struct SoundIoI
 }
 
 static int set_all_device_formats(struct SoundIoDevice *device) {
-    device->format_count = 18;
+    device->format_count = 19;
     device->formats = ALLOCATE(enum SoundIoFormat, device->format_count);
     if (!device->formats)
         return SoundIoErrorNoMem;
@@ -395,14 +395,15 @@ static int set_all_device_formats(struct SoundIoDevice *device) {
     device->formats[7] = SoundIoFormatS24FE;
     device->formats[8] = SoundIoFormatU24NE;
     device->formats[9] = SoundIoFormatU24FE;
-    device->formats[10] = SoundIoFormatFloat64NE;
-    device->formats[11] = SoundIoFormatFloat64FE;
-    device->formats[12] = SoundIoFormatS16NE;
-    device->formats[13] = SoundIoFormatS16FE;
-    device->formats[14] = SoundIoFormatU16NE;
-    device->formats[15] = SoundIoFormatU16FE;
-    device->formats[16] = SoundIoFormatS8;
-    device->formats[17] = SoundIoFormatU8;
+    device->formats[10] = SoundIoFormatS24PLE;
+    device->formats[11] = SoundIoFormatFloat64NE;
+    device->formats[12] = SoundIoFormatFloat64FE;
+    device->formats[13] = SoundIoFormatS16NE;
+    device->formats[14] = SoundIoFormatS16FE;
+    device->formats[15] = SoundIoFormatU16NE;
+    device->formats[16] = SoundIoFormatU16FE;
+    device->formats[11] = SoundIoFormatS8;
+    device->formats[18] = SoundIoFormatU8;
 
     return 0;
 }

--- a/src/pulseaudio.c
+++ b/src/pulseaudio.c
@@ -520,6 +520,7 @@ static pa_sample_format_t to_pulseaudio_format(enum SoundIoFormat format) {
     case SoundIoFormatS24BE:      return PA_SAMPLE_S24_32BE;
     case SoundIoFormatS32LE:      return PA_SAMPLE_S32LE;
     case SoundIoFormatS32BE:      return PA_SAMPLE_S32BE;
+    case SoundIoFormatS24PLE:     return PA_SAMPLE_S24LE;
     case SoundIoFormatFloat32LE:  return PA_SAMPLE_FLOAT32LE;
     case SoundIoFormatFloat32BE:  return PA_SAMPLE_FLOAT32BE;
 

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -105,6 +105,7 @@ int soundio_get_bytes_per_sample(enum SoundIoFormat format) {
     case SoundIoFormatU16BE:      return 2;
     case SoundIoFormatS24LE:      return 4;
     case SoundIoFormatS24BE:      return 4;
+    case SoundIoFormatS24PLE:     return 3;
     case SoundIoFormatU24LE:      return 4;
     case SoundIoFormatU24BE:      return 4;
     case SoundIoFormatS32LE:      return 4;
@@ -131,6 +132,7 @@ const char * soundio_format_string(enum SoundIoFormat format) {
     case SoundIoFormatU16BE:      return "unsigned 16-bit LE";
     case SoundIoFormatS24LE:      return "signed 24-bit LE";
     case SoundIoFormatS24BE:      return "signed 24-bit BE";
+    case SoundIoFormatS24PLE:     return "signed 24-bit packed LE";
     case SoundIoFormatU24LE:      return "unsigned 24-bit LE";
     case SoundIoFormatU24BE:      return "unsigned 24-bit BE";
     case SoundIoFormatS32LE:      return "signed 32-bit LE";

--- a/test/overflow.c
+++ b/test/overflow.c
@@ -27,6 +27,7 @@ static enum SoundIoFormat prioritized_formats[] = {
     SoundIoFormatFloat64FE,
     SoundIoFormatU32NE,
     SoundIoFormatU32FE,
+    SoundIoFormatS24PLE,
     SoundIoFormatU24NE,
     SoundIoFormatU24FE,
     SoundIoFormatU16NE,


### PR DESCRIPTION
Have revisited this and think it's better as two separate pulls, so this is the first to add 24 bit packed integer support to every back end BUT coreaudio, and then the next will be to add to coreaudio with raw-mode support.