### PR TITLE
Add raw device enumeration to Core Audio backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,12 +109,17 @@ if(ENABLE_COREAUDIO)
         find_path(AUDIOUNIT_INCLUDE_DIR NAMES AudioUnit.h)
         find_library(AUDIOUNIT_LIBRARY NAMES AudioUnit)
         include_directories(${AUDIOUNIT_INCLUDE_DIR})
+
+        find_path(AUDIOTOOLBOX_INCLUDE_DIR NAMES AudioToolbox/AudioFormat.h)
+        find_library(AUDIOTOOLBOX_LIBRARY NAMES AudioToolbox)
+        include_directories(${AUDIOTOOLBOX_INCLUDE_DIR})
     else()
         set(STATUS_COREAUDIO "not found")
         set(SOUNDIO_HAVE_COREAUDIO false)
         set(COREAUDIO_LIBRARY "")
         set(COREFOUNDATION_LIBRARY "")
         set(AUDIOUNIT_LIBRARY "")
+        set(AUDIOTOOLBOX_LIBRARY "")
     endif()
 else()
     set(STATUS_COREAUDIO "disabled")
@@ -122,6 +127,7 @@ else()
     set(COREAUDIO_LIBRARY "")
     set(COREFOUNDATION_LIBRARY "")
     set(AUDIOUNIT_LIBRARY "")
+    set(AUDIOTOOLBOX_LIBRARY "")
 endif()
 
 if(ENABLE_WASAPI)
@@ -194,6 +200,7 @@ set(LIBSOUNDIO_LIBS
     ${COREAUDIO_LIBRARY}
     ${COREFOUNDATION_LIBRARY}
     ${AUDIOUNIT_LIBRARY}
+    ${AUDIOTOOLBOX_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
 )
 

--- a/example/sio_microphone.c
+++ b/example/sio_microphone.c
@@ -22,6 +22,7 @@ static enum SoundIoFormat prioritized_formats[] = {
     SoundIoFormatS32FE,
     SoundIoFormatS24NE,
     SoundIoFormatS24FE,
+    SoundIoFormatS24PLE,
     SoundIoFormatS16NE,
     SoundIoFormatS16FE,
     SoundIoFormatFloat64NE,

--- a/example/sio_record.c
+++ b/example/sio_record.c
@@ -24,6 +24,7 @@ static enum SoundIoFormat prioritized_formats[] = {
     SoundIoFormatS32NE,
     SoundIoFormatS32FE,
     SoundIoFormatS24NE,
+    SoundIoFormatS24PLE,
     SoundIoFormatS24FE,
     SoundIoFormatS16NE,
     SoundIoFormatS16FE,

--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -242,6 +242,7 @@ enum SoundIoFormat {
     SoundIoFormatU16BE,     ///< Unsigned 16 bit Big Endian
     SoundIoFormatS24LE,     ///< Signed 24 bit Little Endian using low three bytes in 32-bit word
     SoundIoFormatS24BE,     ///< Signed 24 bit Big Endian using low three bytes in 32-bit word
+    SoundIoFormatS24PLE,    ///< Signed 24 bit Little Endian packed into 3 bytes
     SoundIoFormatU24LE,     ///< Unsigned 24 bit Little Endian using low three bytes in 32-bit word
     SoundIoFormatU24BE,     ///< Unsigned 24 bit Big Endian using low three bytes in 32-bit word
     SoundIoFormatS32LE,     ///< Signed 32 bit Little Endian

--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -423,7 +423,9 @@ struct SoundIoDevice {
     /// provided by a software mixing service such as dmix or PulseAudio (see
     /// SoundIoDevice::is_raw). If it is a raw device,
     /// current_format is meaningless;
-    /// the device has no current format until you open it. On the other hand,
+    /// the device has no current format until you open it (with the
+    /// exclusion of Core Audio on macOS where the device will always
+    /// be set to a valid format). On the other hand,
     /// if it is a virtual device, current_format describes the
     /// destination sample format that your audio will be converted to. Or,
     /// if you're the lucky first application to open the device, you might
@@ -585,6 +587,14 @@ struct SoundIoOutStream {
     /// stream. Defaults to `false`.
     bool non_terminal_hint;
 
+    /// On macOS, even in raw mode the hardware format may not always match the
+    /// virtual format that the device accepts IO in. If the virtual and physical
+    /// formats for this stream match (usually only true for integer formats)
+    /// this flag will be true. Otherwise the output is typically 32 bit float
+    /// converted to integer by the kernel device driver (NOT Core Audio). Integer
+    /// virtual formats (required for "bit-perfect" playback) are typically only supported
+    /// by external USB DACs.
+    bool physical_format_match;
 
     /// computed automatically when you call ::soundio_outstream_open
     int bytes_per_frame;

--- a/src/alsa.c
+++ b/src/alsa.c
@@ -236,6 +236,7 @@ static snd_pcm_format_t to_alsa_fmt(enum SoundIoFormat fmt) {
     case SoundIoFormatS24BE:        return SND_PCM_FORMAT_S24_BE;
     case SoundIoFormatU24LE:        return SND_PCM_FORMAT_U24_LE;
     case SoundIoFormatU24BE:        return SND_PCM_FORMAT_U24_BE;
+    case SoundIoFormatS24PLE:       return SND_PCM_FORMAT_S24_3LE;
     case SoundIoFormatS32LE:        return SND_PCM_FORMAT_S32_LE;
     case SoundIoFormatS32BE:        return SND_PCM_FORMAT_S32_BE;
     case SoundIoFormatU32LE:        return SND_PCM_FORMAT_U32_LE;
@@ -350,6 +351,7 @@ static int probe_open_device(struct SoundIoDevice *device, snd_pcm_t *handle, in
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_S24_BE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_U24_LE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_U24_BE);
+    snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_S24_3LE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_S32_LE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_S32_BE);
     snd_pcm_format_mask_set(fmt_mask, SND_PCM_FORMAT_U32_LE);
@@ -364,7 +366,7 @@ static int probe_open_device(struct SoundIoDevice *device, snd_pcm_t *handle, in
 
     if (!device->formats) {
         snd_pcm_hw_params_get_format_mask(hwparams, fmt_mask);
-        device->formats = ALLOCATE(enum SoundIoFormat, 18);
+        device->formats = ALLOCATE(enum SoundIoFormat, 19);
         if (!device->formats)
             return SoundIoErrorNoMem;
 
@@ -379,6 +381,7 @@ static int probe_open_device(struct SoundIoDevice *device, snd_pcm_t *handle, in
         test_fmt_mask(device, fmt_mask, SoundIoFormatS24BE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatU24LE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatU24BE);
+        test_fmt_mask(device, fmt_mask, SoundIoFormatS24PLE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatS32LE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatS32BE);
         test_fmt_mask(device, fmt_mask, SoundIoFormatU32LE);

--- a/src/coreaudio.h
+++ b/src/coreaudio.h
@@ -60,7 +60,6 @@ struct SoundIoOutStreamCoreAudio {
     struct SoundIoChannelArea areas[SOUNDIO_MAX_CHANNELS];
     struct SoundIoAtomicBool output_format_match;
     bool revert_format;
-    bool raw_integer_mode_support;
 };
 
 struct SoundIoInStreamCoreAudio {

--- a/src/coreaudio.h
+++ b/src/coreaudio.h
@@ -47,6 +47,10 @@ struct SoundIoCoreAudio {
 
 struct SoundIoOutStreamCoreAudio {
     AudioComponentInstance instance;
+    AudioDeviceIOProcID io_proc_id;
+    AudioStreamID raw_stream_id;
+    AudioStreamBasicDescription hardware_format;
+    AudioStreamBasicDescription previous_hardware_format;
     AudioBufferList *io_data;
     int buffer_index;
     int frames_left;
@@ -54,6 +58,9 @@ struct SoundIoOutStreamCoreAudio {
     double hardware_latency;
     float volume;
     struct SoundIoChannelArea areas[SOUNDIO_MAX_CHANNELS];
+    struct SoundIoAtomicBool output_format_match;
+    bool revert_format;
+    bool raw_integer_mode_support;
 };
 
 struct SoundIoInStreamCoreAudio {

--- a/src/dummy.c
+++ b/src/dummy.c
@@ -380,7 +380,7 @@ static int instream_get_latency_dummy(struct SoundIoPrivate *si, struct SoundIoI
 }
 
 static int set_all_device_formats(struct SoundIoDevice *device) {
-    device->format_count = 18;
+    device->format_count = 19;
     device->formats = ALLOCATE(enum SoundIoFormat, device->format_count);
     if (!device->formats)
         return SoundIoErrorNoMem;
@@ -395,14 +395,15 @@ static int set_all_device_formats(struct SoundIoDevice *device) {
     device->formats[7] = SoundIoFormatS24FE;
     device->formats[8] = SoundIoFormatU24NE;
     device->formats[9] = SoundIoFormatU24FE;
-    device->formats[10] = SoundIoFormatFloat64NE;
-    device->formats[11] = SoundIoFormatFloat64FE;
-    device->formats[12] = SoundIoFormatS16NE;
-    device->formats[13] = SoundIoFormatS16FE;
-    device->formats[14] = SoundIoFormatU16NE;
-    device->formats[15] = SoundIoFormatU16FE;
-    device->formats[16] = SoundIoFormatS8;
-    device->formats[17] = SoundIoFormatU8;
+    device->formats[10] = SoundIoFormatS24PLE;
+    device->formats[11] = SoundIoFormatFloat64NE;
+    device->formats[12] = SoundIoFormatFloat64FE;
+    device->formats[13] = SoundIoFormatS16NE;
+    device->formats[14] = SoundIoFormatS16FE;
+    device->formats[15] = SoundIoFormatU16NE;
+    device->formats[16] = SoundIoFormatU16FE;
+    device->formats[11] = SoundIoFormatS8;
+    device->formats[18] = SoundIoFormatU8;
 
     return 0;
 }

--- a/src/pulseaudio.c
+++ b/src/pulseaudio.c
@@ -520,6 +520,7 @@ static pa_sample_format_t to_pulseaudio_format(enum SoundIoFormat format) {
     case SoundIoFormatS24BE:      return PA_SAMPLE_S24_32BE;
     case SoundIoFormatS32LE:      return PA_SAMPLE_S32LE;
     case SoundIoFormatS32BE:      return PA_SAMPLE_S32BE;
+    case SoundIoFormatS24PLE:     return PA_SAMPLE_S24LE;
     case SoundIoFormatFloat32LE:  return PA_SAMPLE_FLOAT32LE;
     case SoundIoFormatFloat32BE:  return PA_SAMPLE_FLOAT32BE;
 

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -105,6 +105,7 @@ int soundio_get_bytes_per_sample(enum SoundIoFormat format) {
     case SoundIoFormatU16BE:      return 2;
     case SoundIoFormatS24LE:      return 4;
     case SoundIoFormatS24BE:      return 4;
+    case SoundIoFormatS24PLE:     return 3;
     case SoundIoFormatU24LE:      return 4;
     case SoundIoFormatU24BE:      return 4;
     case SoundIoFormatS32LE:      return 4;
@@ -131,6 +132,7 @@ const char * soundio_format_string(enum SoundIoFormat format) {
     case SoundIoFormatU16BE:      return "unsigned 16-bit LE";
     case SoundIoFormatS24LE:      return "signed 24-bit LE";
     case SoundIoFormatS24BE:      return "signed 24-bit BE";
+    case SoundIoFormatS24PLE:     return "signed 24-bit packed LE";
     case SoundIoFormatU24LE:      return "unsigned 24-bit LE";
     case SoundIoFormatU24BE:      return "unsigned 24-bit BE";
     case SoundIoFormatS32LE:      return "signed 32-bit LE";

--- a/test/overflow.c
+++ b/test/overflow.c
@@ -27,6 +27,7 @@ static enum SoundIoFormat prioritized_formats[] = {
     SoundIoFormatFloat64FE,
     SoundIoFormatU32NE,
     SoundIoFormatU32FE,
+    SoundIoFormatS24PLE,
     SoundIoFormatU24NE,
     SoundIoFormatU24FE,
     SoundIoFormatU16NE,


### PR DESCRIPTION
Replaces #165, with 24 bit packed definitions for other platforms in separate pull (#225). No code changes, just rebased and reorganised the commits a bit. Please note this code worked great for me in 2017 but I don't actually have any Mac hardware currently so untested, but AFAIK the API has not changed.