### PR TITLE
Autogenerate a .pc file during build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -223,6 +223,12 @@ configure_file(
     ${DOXYGEN_CONF_FILE}
 )
 
+configure_file(
+   ${libsoundio_SOURCE_DIR}/soundio.pc.in
+   ${libsoundio_BINARY_DIR}/soundio.pc
+   @ONLY
+)
+
 if(BUILD_DYNAMIC_LIBS)
     add_library(libsoundio_shared SHARED ${LIBSOUNDIO_SOURCES})
     set_target_properties(libsoundio_shared PROPERTIES
@@ -249,6 +255,9 @@ endif()
 install(FILES
     ${LIBSOUNDIO_HEADERS}
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/soundio")
+install(
+    FILES ${libsoundio_BINARY_DIR}/soundio.pc
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
 # Example Programs
 

--- a/soundio.pc.in
+++ b/soundio.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/include/soundio
+
+Name: soundio
+Description: Cross-platform audio input and output for real-time & consumer software
+URL: http://libsound.io/
+Version: 2.0.0
+Cflags: -I${includedir}
+Libs: -L${libdir} -lsoundio


### PR DESCRIPTION
Based on https://cmake.org/pipermail/cmake/2018-March/067293.html - generates and installs a .pc file to allow use of pkg-config to incorporate the library in other projects.