### PR TITLE
LIBSOUNDIO_LIBS as CMake Parent Scope Variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,3 +386,5 @@ message(
     "* CoreAudio  (optional)        : ${STATUS_COREAUDIO}\n"
     "* WASAPI     (optional)        : ${STATUS_WASAPI}\n"
 )
+
+set(LIBSOUNDIO_LIBS ${LIBSOUNDIO_LIBS} PARENT_SCOPE)


### PR DESCRIPTION
Setting the LIBSOUNDIO_LIBS to Parent Scope will allow it to be used as a CMake submodule like so:

```
add_subdirectory(libsoundio)
target_link_libraries(${PROJECT_NAME} PRIVATE
    ${LIBSOUNDIO_LIBS}
    )
```