### PR TITLE
docs: fix simple typo, underyling -> underlying

### DIFF
--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -1142,7 +1142,7 @@ SOUNDIO_EXPORT int soundio_instream_begin_read(struct SoundIoInStream *instream,
 /// * #SoundIoErrorStreaming
 SOUNDIO_EXPORT int soundio_instream_end_read(struct SoundIoInStream *instream);
 
-/// If the underyling device supports pausing, this pauses the stream and
+/// If the underlying device supports pausing, this pauses the stream and
 /// prevents SoundIoInStream::read_callback from being called. Otherwise this returns
 /// #SoundIoErrorIncompatibleDevice.
 /// This function may be called from any thread.


### PR DESCRIPTION
There is a small typo in soundio/soundio.h.

Should read `underlying` rather than `underyling`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md