### PR TITLE
Fix endianness detection on Windows ARM platforms

### DIFF
--- a/soundio/endian.h
+++ b/soundio/endian.h
@@ -90,6 +90,10 @@
 #define SOUNDIO_OS_LITTLE_ENDIAN
 #elif defined(__bfin__)
 #define SOUNDIO_OS_LITTLE_ENDIAN
+#elif defined(_M_ARM)
+#define SOUNDIO_OS_LITTLE_ENDIAN
+#elif defined(_M_ARM64)
+#define SOUNDIO_OS_LITTLE_ENDIAN
 #else
 #error unable to detect endianness
 #endif


### PR DESCRIPTION
Building libsoundio for ARM64 on Windows fails because there is no handling of Windows ARM platforms in endian.h. This PR simply adds the appropriate handling. With this small patch, libsoundio builds and works perfectly on ARM64.

Note: Even though ARM is bi-endian, Windows on ARM is always little-endian.