### PR TITLE
CMake 3.19+ compatability with MSVC.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -312,7 +312,6 @@ if(BUILD_TESTS)
     if(MSVC)
         set_property(SOURCE "${libsoundio_SOURCE_DIR}/test/latency.c" PROPERTY LANGUAGE CXX)
     endif()
-    target_link_libraries(latency LINK_PUBLIC ${LIBSOUNDIO_LIBS} ${LIBM})
     set_target_properties(latency PROPERTIES
         LINKER_LANGUAGE C
         COMPILE_FLAGS ${LIB_CFLAGS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,11 +199,12 @@ set(LIBSOUNDIO_LIBS
 
 if(MSVC)
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} /Wall")
-    set(LIB_CFLAGS "/TP /W4")
+    set(LIB_CFLAGS "/W4")
+    set_property(SOURCE ${LIBSOUNDIO_SOURCES} PROPERTY LANGUAGE CXX)
     set(EXAMPLE_CFLAGS "/W4")
     set(TEST_CFLAGS "${LIB_CFLAGS}")
     set(TEST_LDFLAGS " ")
-    set(LIBM " ")
+    set(LIBM "")
 else()
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror -pedantic")
     set(LIB_CFLAGS "-std=c11 -fvisibility=hidden -Wall -Werror=strict-prototypes -Werror=old-style-definition -Werror=missing-prototypes -D_REENTRANT -D_POSIX_C_SOURCE=200809L -Wno-missing-braces")
@@ -308,11 +309,20 @@ if(BUILD_TESTS)
     )
 
     add_executable(latency "${libsoundio_SOURCE_DIR}/test/latency.c" ${LIBSOUNDIO_SOURCES})
+    if(MSVC)
+        set_property(SOURCE "${libsoundio_SOURCE_DIR}/test/latency.c" PROPERTY LANGUAGE CXX)
+    endif()
     target_link_libraries(latency LINK_PUBLIC ${LIBSOUNDIO_LIBS} ${LIBM})
     set_target_properties(latency PROPERTIES
         LINKER_LANGUAGE C
         COMPILE_FLAGS ${LIB_CFLAGS}
     )
+    if(BUILD_DYNAMIC_LIBS)
+        target_link_libraries(latency libsoundio_shared ${LIBM})
+    else()
+        target_link_libraries(latency libsoundio_static ${LIBSOUNDIO_LIBS} ${LIBM})
+    endif()
+
 
     add_executable(underflow test/underflow.c)
     set_target_properties(underflow PROPERTIES


### PR DESCRIPTION
There are currently build issues with newer CMake versions on Windows using MSVC. The /TP flag is not being propagated properly anymore in newer CMake versions (See [https://gitlab.kitware.com/cmake/cmake/-/issues/22356](https://gitlab.kitware.com/cmake/cmake/-/issues/22356)), which results in the __cplusplus flag not existing for the atomics.h -> stdatomics.h related compile errors with MSVC. 

There is also an issue of an empty .lib being added to the linker with MSVC.

Both should be fixed by this PR.