### PR TITLE
Always use WASAPI's callback mode

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -334,6 +334,7 @@ void soundio_os_mutex_unlock(struct SoundIoOsMutex *mutex) {
 #endif
 }
 
+// XXX: do we still need this? and other stuff like it?
 struct SoundIoOsCond * soundio_os_cond_create(void) {
     struct SoundIoOsCond *cond = ALLOCATE(struct SoundIoOsCond, 1);
 

--- a/src/os.c
+++ b/src/os.c
@@ -334,7 +334,6 @@ void soundio_os_mutex_unlock(struct SoundIoOsMutex *mutex) {
 #endif
 }
 
-// XXX: do we still need this? and other stuff like it?
 struct SoundIoOsCond * soundio_os_cond_create(void) {
     struct SoundIoOsCond *cond = ALLOCATE(struct SoundIoOsCond, 1);
 

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -1283,7 +1283,7 @@ static int outstream_do_open(struct SoundIoPrivate *si, struct SoundIoOutStreamP
         flags = osw->need_resample ? AUDCLNT_STREAMFLAGS_AUTOCONVERTPCM | AUDCLNT_STREAMFLAGS_SRC_DEFAULT_QUALITY : 0;
         share_mode = AUDCLNT_SHAREMODE_SHARED;
         periodicity = 0;
-        buffer_duration = to_reference_time(4.0);
+        buffer_duration = to_reference_time(outstream->software_latency);
     }
     to_wave_format_layout(&outstream->layout, &wave_format);
     to_wave_format_format(outstream->format, &wave_format);
@@ -1820,7 +1820,7 @@ static int instream_do_open(struct SoundIoPrivate *si, struct SoundIoInStreamPri
         flags = 0;
         share_mode = AUDCLNT_SHAREMODE_SHARED;
         periodicity = 0;
-        buffer_duration = to_reference_time(4.0);
+        buffer_duration = to_reference_time(instream->software_latency);
     }
     to_wave_format_layout(&instream->layout, &wave_format);
     to_wave_format_format(instream->format, &wave_format);

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -30,26 +30,10 @@
 #define E_NOTFOUND 0x80070490
 #endif //E_NOTFOUND
 
-#ifdef __cplusplus
-// In C++ mode, IsEqualGUID() takes its arguments by reference
-#define IS_EQUAL_GUID(a, b) IsEqualGUID(*(a), *(b))
-#define IS_EQUAL_IID(a, b) IsEqualIID((a), *(b))
-
-// And some constants are passed by reference
-#define IID_IAUDIOCLIENT                      (IID_IAudioClient)
-#define IID_IMMENDPOINT                       (IID_IMMEndpoint)
-#define IID_IAUDIOCLOCKADJUSTMENT             (IID_IAudioClockAdjustment)
-#define IID_IAUDIOSESSIONCONTROL              (IID_IAudioSessionControl)
-#define IID_IAUDIORENDERCLIENT                (IID_IAudioRenderClient)
-#define IID_IMMDEVICEENUMERATOR               (IID_IMMDeviceEnumerator)
-#define IID_IAUDIOCAPTURECLIENT               (IID_IAudioCaptureClient)
-#define IID_ISIMPLEAUDIOVOLUME                (IID_ISimpleAudioVolume)
-#define CLSID_MMDEVICEENUMERATOR              (CLSID_MMDeviceEnumerator)
-#define PKEY_DEVICE_FRIENDLYNAME              (PKEY_Device_FriendlyName)
-#define PKEY_AUDIOENGINE_DEVICEFORMAT         (PKEY_AudioEngine_DeviceFormat)
-
 // And some GUID are never implemented (Ignoring the INITGUID define)
-static const CLSID CLSID_MMDeviceEnumerator  = __uuidof(MMDeviceEnumerator);
+static const CLSID CLSID_MMDeviceEnumerator = {
+    0xbcde0395, 0xe52f, 0x467c, {0x8e, 0x3d, 0xc4, 0x57, 0x92, 0x91, 0x69, 0x2e}
+};
 static const IID   IID_IMMDeviceEnumerator   = {
     //MIDL_INTERFACE("A95664D2-9614-4F35-A746-DE8DB63617E6")
     0xa95664d2, 0x9614, 0x4f35, {0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6}
@@ -90,6 +74,24 @@ static const IID IID_ISimpleAudioVolume = {
     //MIDL_INTERFACE("87ce5498-68d6-44e5-9215-6da47ef883d8")
     0x87ce5498, 0x68d6, 0x44e5,{ 0x92, 0x15, 0x6d, 0xa4, 0x7e, 0xf8, 0x83, 0xd8 }
 };
+
+#ifdef __cplusplus
+// In C++ mode, IsEqualGUID() takes its arguments by reference
+#define IS_EQUAL_GUID(a, b) IsEqualGUID(*(a), *(b))
+#define IS_EQUAL_IID(a, b) IsEqualIID((a), *(b))
+
+// And some constants are passed by reference
+#define IID_IAUDIOCLIENT                      (IID_IAudioClient)
+#define IID_IMMENDPOINT                       (IID_IMMEndpoint)
+#define IID_IAUDIOCLOCKADJUSTMENT             (IID_IAudioClockAdjustment)
+#define IID_IAUDIOSESSIONCONTROL              (IID_IAudioSessionControl)
+#define IID_IAUDIORENDERCLIENT                (IID_IAudioRenderClient)
+#define IID_IMMDEVICEENUMERATOR               (IID_IMMDeviceEnumerator)
+#define IID_IAUDIOCAPTURECLIENT               (IID_IAudioCaptureClient)
+#define IID_ISIMPLEAUDIOVOLUME                (IID_ISimpleAudioVolume)
+#define CLSID_MMDEVICEENUMERATOR              (CLSID_MMDeviceEnumerator)
+#define PKEY_DEVICE_FRIENDLYNAME              (PKEY_Device_FriendlyName)
+#define PKEY_AUDIOENGINE_DEVICEFORMAT         (PKEY_AudioEngine_DeviceFormat)
 
 #else
 #define IS_EQUAL_GUID(a, b) IsEqualGUID((a), (b))

--- a/src/wasapi.h
+++ b/src/wasapi.h
@@ -73,7 +73,6 @@ struct SoundIoOutStreamWasapi {
     struct SoundIoOsCond *start_cond;
     struct SoundIoAtomicFlag thread_exit_flag;
     bool is_raw;
-    int writable_frame_count;
     UINT32 buffer_frame_count;
     int write_frame_count;
     HANDLE h_event;


### PR DESCRIPTION
# TLDR

This PR modifies the WASAPI backend to use event based callbacks, fixing a problem where small buffers would unnecessarily underflow due to issues with how Windows handles timer resolution.

# Full Explanation

Presently, the WASAPI backend when running in shared mode defaults to a 4 second buffer, and uses a sleep condition variable to time the write call back, the intention being that you don't have to use the whole buffer.

Unfortunately, if you only use ~23-40ms of the buffer, you'll get underflows because sleep condition variables are subject to Windows' timer interval. If you use [timeBeginPeriod](https://docs.microsoft.com/en-us/windows/win32/api/timeapi/nf-timeapi-timebeginperiod) to lower the interval, or if someone else has already lowered it ([it's kind of global ish maybe](https://randomascii.wordpress.com/2020/10/04/windows-timer-resolution-the-great-rule-change/)), the problem goes away. WASAPI appears to lower the interval itself automatically, but not enough, even when modifying libsoundio to request a smaller buffer. To check the current timer interval, see [ClockRes](https://docs.microsoft.com/en-us/sysinternals/downloads/clockres).

This PR solves this problem by modifying the WASAPI backend to use `AUDCLNT_STREAMFLAGS_EVENTCALLBACK` mode. The code changes are minimal since this mode was already used for raw devices. In this mode, `WaitForSingleObject` is used to time the callbacks instead of `SleepConditionVariableCS`. I'm under the impression that `WaitForSingleObject` doesn't rely on the timer period unless it times out, but regardless, WASAPI does a better job of setting the timer period low enough for you in this mode.

With these changes, I experience no underflows at the lowest interval Windows is willing to give me (23.49ms.)

# WIP

## Clearing The Buffer

> "On systems that support clearing the buffer, this defaults to a large latency, potentially upwards of 2 seconds, with the understanding that you will call soundio_outstream_clear_buffer when you want to reduce the latency to 0."

*libsoundio docs*

There's nothing stopping me from continuing to support clearing the outstream in shared mode, and adding support for clearing it in exclusive mode, despite neither defaulting to a large buffer size with these changes.

I could add support for this, and modify the docs accordingly, or I could remove support and leave the docs alone.

It's not clear to me which is better because I don't understand the reason for defaulting to a large buffer on some backends to begin with--is there a use case where it's beneficial to give the user a significantly larger buffer than they asked for?

If you want, we can punt on this--I can do the safe thing by implementing this according to the current docs, and then we can revisit this later, I'm planning on suggesting a change to this API anyway and can bring it up again then.

## Min Frame Counts

I left the min frame count calculation alone. I noticed that for exclusive mode, the min frame count and max frame count are the same--I'm not sure if I should do the same thing here. Presumably there's no reason to not fill the entire buffer with this change in place?