### PR TITLE
Use `kAudioObjectPropertyElementMain` on macOS 12

### DIFF
--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -9,6 +9,11 @@
 #include "soundio_private.h"
 
 #include <assert.h>
+#include <AvailabilityMacros.h>
+
+#if !defined(MAC_OS_VERSION_12_0) || (MAC_OS_X_VERSION_MIN_REQUIRED < MAC_OS_VERSION_12_0)
+    #define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
 
 static const int OUTPUT_ELEMENT = 0;
 static const int INPUT_ELEMENT = 1;
@@ -17,77 +22,77 @@ static AudioObjectPropertyAddress device_listen_props[] = {
     {
         kAudioDevicePropertyDeviceHasChanged,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioObjectPropertyName,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyDeviceUID,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyStreamConfiguration,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyStreamConfiguration,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyPreferredChannelLayout,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyPreferredChannelLayout,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyNominalSampleRate,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyNominalSampleRate,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyAvailableNominalSampleRates,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyAvailableNominalSampleRates,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyBufferFrameSize,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyBufferFrameSize,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyBufferFrameSizeRange,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyBufferFrameSizeRange,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
 };
 
@@ -141,7 +146,7 @@ static void destroy_ca(struct SoundIoPrivate *si) {
     AudioObjectPropertyAddress prop_address = {
         kAudioHardwarePropertyDevices,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
     AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &prop_address, on_devices_changed, si);
 
@@ -434,7 +439,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
     AudioObjectPropertyAddress prop_address = {
         kAudioHardwarePropertyDevices,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
 
     if ((os_err = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject,
@@ -503,7 +508,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
         prop_address.mSelector = kAudioObjectPropertyName;
         prop_address.mScope = kAudioObjectPropertyScopeGlobal;
-        prop_address.mElement = kAudioObjectPropertyElementMaster;
+        prop_address.mElement = kAudioObjectPropertyElementMain;
         io_size = sizeof(CFStringRef);
         if (rd.string_ref) {
             CFRelease(rd.string_ref);
@@ -525,7 +530,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
         prop_address.mSelector = kAudioDevicePropertyDeviceUID;
         prop_address.mScope = kAudioObjectPropertyScopeGlobal;
-        prop_address.mElement = kAudioObjectPropertyElementMaster;
+        prop_address.mElement = kAudioObjectPropertyElementMain;
         io_size = sizeof(CFStringRef);
         if (rd.string_ref) {
             CFRelease(rd.string_ref);
@@ -552,7 +557,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             io_size = 0;
             prop_address.mSelector = kAudioDevicePropertyStreamConfiguration;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             if ((os_err = AudioObjectGetPropertyDataSize(device_id, &prop_address, 0, NULL, &io_size))) {
                 deinit_refresh_devices(&rd);
                 return SoundIoErrorOpeningDevice;
@@ -603,7 +608,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyPreferredChannelLayout;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             if (!(os_err = AudioObjectGetPropertyDataSize(device_id, &prop_address,
                 0, NULL, &io_size)))
             {
@@ -643,7 +648,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyNominalSampleRate;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             io_size = sizeof(double);
             double value;
             if ((os_err = AudioObjectGetPropertyData(device_id, &prop_address, 0, NULL,
@@ -669,7 +674,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             } else {
                 prop_address.mSelector = kAudioDevicePropertyAvailableNominalSampleRates;
                 prop_address.mScope = aim_to_scope(aim);
-                prop_address.mElement = kAudioObjectPropertyElementMaster;
+                prop_address.mElement = kAudioObjectPropertyElementMain;
                 if ((os_err = AudioObjectGetPropertyDataSize(device_id, &prop_address, 0, NULL,
                     &io_size)))
                 {
@@ -715,7 +720,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyBufferFrameSize;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             io_size = sizeof(UInt32);
             UInt32 buffer_frame_size;
             if ((os_err = AudioObjectGetPropertyData(device_id, &prop_address, 0, NULL,
@@ -729,7 +734,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyBufferFrameSizeRange;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             io_size = sizeof(AudioValueRange);
             AudioValueRange avr;
             if ((os_err = AudioObjectGetPropertyData(device_id, &prop_address, 0, NULL,
@@ -743,7 +748,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyLatency;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             io_size = sizeof(UInt32);
             if ((os_err = AudioObjectGetPropertyData(device_id, &prop_address, 0, NULL,
                 &io_size, &dca->latency_frames)))
@@ -894,7 +899,7 @@ static void outstream_destroy_ca(struct SoundIoPrivate *si, struct SoundIoOutStr
     AudioObjectPropertyAddress prop_address = {
         kAudioDeviceProcessorOverload,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
     AudioObjectRemovePropertyListener(dca->device_id, &prop_address, on_outstream_device_overload, os);
 
@@ -1151,7 +1156,7 @@ static void instream_destroy_ca(struct SoundIoPrivate *si, struct SoundIoInStrea
     AudioObjectPropertyAddress prop_address = {
         kAudioDeviceProcessorOverload,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
     AudioObjectRemovePropertyListener(dca->device_id, &prop_address, on_instream_device_overload, is);
 
@@ -1230,7 +1235,7 @@ static int instream_open_ca(struct SoundIoPrivate *si, struct SoundIoInStreamPri
     AudioObjectPropertyAddress prop_address;
     prop_address.mSelector = kAudioDevicePropertyStreamConfiguration;
     prop_address.mScope = kAudioObjectPropertyScopeInput;
-    prop_address.mElement = kAudioObjectPropertyElementMaster;
+    prop_address.mElement = kAudioObjectPropertyElementMain;
     io_size = 0;
     if ((os_err = AudioObjectGetPropertyDataSize(dca->device_id, &prop_address,
         0, NULL, &io_size)))
@@ -1437,7 +1442,7 @@ int soundio_coreaudio_init(struct SoundIoPrivate *si) {
     AudioObjectPropertyAddress prop_address = {
         kAudioHardwarePropertyDevices,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
     if ((err = AudioObjectAddPropertyListener(kAudioObjectSystemObject, &prop_address,
         on_devices_changed, si)))


### PR DESCRIPTION
As mentioned in #256, builds on macOS 12 are failing due to the usage of deprecated `kAudioObjectPropertyElementMaster` (now `kAudioObjectPropertyElementMain`). 

The issue was addressed in #259 which was unfortunately backwards incompatible with previous macOS versions. I've included a backwards compatible fix here.