### PR TITLE
void debug-only variables to prevent warnings if NDEBUG is defined

### DIFF
--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -381,6 +381,14 @@ struct SoundIo {
     /// Optional: JACK error callback.
     /// See SoundIo::jack_info_callback
     void (*jack_error_callback)(const char *msg);
+
+
+    /// Optional: ALSA error callback.
+    /// By default, libsoundio sets this to an empty function in order to
+    /// silence stdio messages from ALSA. You may override the behavior by
+    /// setting this to `NULL` to reinstate ALSAs default behaviour of printing
+    /// to stderr.
+    void(* alsa_error_callback) (const char *file, int line, const char *function, int err, const char *fmt,...);
 };
 
 /// The size of this struct is not part of the API or ABI.

--- a/soundio/soundio.h
+++ b/soundio/soundio.h
@@ -385,7 +385,7 @@ struct SoundIo {
 
     /// Optional: ALSA error callback.
     /// By default, libsoundio sets this to an empty function in order to
-    /// silence stdio messages from ALSA. You may override the behavior by
+    /// silence stderr messages from ALSA. You may override the behavior by
     /// setting this to `NULL` to reinstate ALSAs default behaviour of printing
     /// to stderr.
     void(* alsa_error_callback) (const char *file, int line, const char *function, int err, const char *fmt,...);

--- a/src/alsa.c
+++ b/src/alsa.c
@@ -1867,6 +1867,8 @@ int soundio_alsa_init(struct SoundIoPrivate *si) {
     struct SoundIoAlsa *sia = &si->backend_data.alsa;
     int err;
 
+    snd_lib_error_set_handler(si->pub.alsa_error_callback);
+
     sia->notify_fd = -1;
     sia->notify_wd = -1;
     SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(sia->abort_flag);

--- a/src/os.c
+++ b/src/os.c
@@ -742,6 +742,7 @@ void soundio_os_deinit_mirrored_memory(struct SoundIoOsMirroredMemory *mem) {
 #else
     int err = munmap(mem->address, 2 * mem->capacity);
     assert(!err);
+    (void) err;
 #endif
     mem->address = NULL;
 }

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -171,7 +171,9 @@ void soundio_destroy(struct SoundIo *soundio) {
 }
 
 static void do_nothing_cb(struct SoundIo *soundio) { }
-static void default_msg_callback(const char *msg) { }
+static void default_jack_msg_callback(const char *msg) { }
+static void snd_lib_error_default(const char *file, int line, const char *function, int err, const char *fmt, ...)
+{ }
 
 static void default_backend_disconnect_cb(struct SoundIo *soundio, int err) {
     soundio_panic("libsoundio: backend disconnected: %s", soundio_strerror(err));
@@ -199,8 +201,9 @@ struct SoundIo *soundio_create(void) {
     soundio->on_events_signal = do_nothing_cb;
     soundio->app_name = "SoundIo";
     soundio->emit_rtprio_warning = default_emit_rtprio_warning;
-    soundio->jack_info_callback = default_msg_callback;
-    soundio->jack_error_callback = default_msg_callback;
+    soundio->jack_info_callback = default_jack_msg_callback;
+    soundio->jack_error_callback = default_jack_msg_callback;
+    soundio->alsa_error_callback = snd_lib_error_default;
     return soundio;
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -35,6 +35,7 @@ char *soundio_alloc_sprintf(int *len, const char *format, ...) {
 
     int len2 = vsnprintf(mem, required_size, format, ap2);
     assert(len2 == len1);
+    (void)len2;
 
     va_end(ap2);
     va_end(ap);


### PR DESCRIPTION
fix https://github.com/andrewrk/libsoundio/issues/277