### PR TITLE
Cmake Support for MSVC builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,9 @@
-cmake_minimum_required(VERSION 2.8.5)
+# Copyright (c) 2023 Andrew Kelley
+# This file is MIT licensed.
+# See http://opensource.org/licenses/MIT
+
+cmake_minimum_required(VERSION 3.0.0)
+
 project(libsoundio C)
 set(CMAKE_MODULE_PATH ${libsoundio_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
@@ -22,6 +27,7 @@ set(LIBSOUNDIO_VERSION_MINOR 0)
 set(LIBSOUNDIO_VERSION_PATCH 0)
 set(LIBSOUNDIO_VERSION "${LIBSOUNDIO_VERSION_MAJOR}.${LIBSOUNDIO_VERSION_MINOR}.${LIBSOUNDIO_VERSION_PATCH}")
 message("Configuring libsoundio version ${LIBSOUNDIO_VERSION}")
+
 
 if(NOT SOUNDIO_STATIC_LIBNAME)
     set(SOUNDIO_STATIC_LIBNAME soundio)
@@ -203,7 +209,6 @@ if(MSVC)
     set(EXAMPLE_CFLAGS "/W4")
     set(TEST_CFLAGS "${LIB_CFLAGS}")
     set(TEST_LDFLAGS " ")
-    set(LIBM " ")
 else()
     set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -Werror -pedantic")
     set(LIB_CFLAGS "-std=c11 -fvisibility=hidden -Wall -Werror=strict-prototypes -Werror=old-style-definition -Werror=missing-prototypes -D_REENTRANT -D_POSIX_C_SOURCE=200809L -Wno-missing-braces")
@@ -386,3 +391,5 @@ message(
     "* CoreAudio  (optional)        : ${STATUS_COREAUDIO}\n"
     "* WASAPI     (optional)        : ${STATUS_WASAPI}\n"
 )
+
+

--- a/example/sio_microphone.c
+++ b/example/sio_microphone.c
@@ -46,10 +46,14 @@ static int prioritized_sample_rates[] = {
 };
 
 
+#ifndef _MSC_VER
 __attribute__ ((cold))
 __attribute__ ((noreturn))
 __attribute__ ((format (printf, 1, 2)))
 static void panic(const char *format, ...) {
+#else
+__declspec(noreturn) static void panic(const char *format, ...) {
+#endif
     va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);

--- a/example/sio_record.c
+++ b/example/sio_record.c
@@ -12,7 +12,13 @@
 #include <string.h>
 #include <math.h>
 #include <errno.h>
+
+#ifndef _MSC_VER
 #include <unistd.h>
+#else
+#include <Windows.h>
+#define sleep(x) Sleep(x * 1000)
+#endif
 
 struct RecordContext {
     struct SoundIoRingBuffer *ring_buffer;

--- a/src/atomics.h
+++ b/src/atomics.h
@@ -15,7 +15,7 @@
 #ifdef _MSC_VER
 #define SOUNDIO_USE_MSVC_NATIVE_C_ATOMICS
 #else
-#define SOUNDIO_USE_GNU_ATOMICS
+#define SOUNDIO_USE_UNIX_ATOMICS
 #endif // ifdef _MSC_VER
 
 #endif // ifdef __cplusplus
@@ -79,7 +79,7 @@ struct SoundIoAtomicULong {
 
 #endif
 
-#ifdef SOUNDIO_USE_GNU_ATOMICS
+#ifdef SOUNDIO_USE_UNIX_ATOMICS
 
 #include <stdatomic.h>
 
@@ -107,8 +107,8 @@ struct SoundIoAtomicULong {
 #define SOUNDIO_ATOMIC_FETCH_ADD_(a, delta) atomic_fetch_add(&a.x, delta)
 #define SOUNDIO_ATOMIC_STORE_(a, value) atomic_store(&a.x, value)
 #define SOUNDIO_ATOMIC_EXCHANGE_(a, value) atomic_exchange(&a.x, value)
-#define SOUNDIO_ATOMIC_FLAG_TEST_AND_SET_(a) atomic_flag_test_and_set(&a.x)
-#define SOUNDIO_ATOMIC_FLAG_CLEAR_(a) atomic_flag_clear(&a.x)
+#define SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(a) atomic_flag_test_and_set(&a.x)
+#define SOUNDIO_ATOMIC_FLAG_CLEAR(a) atomic_flag_clear(&a.x)
 #define SOUNDIO_ATOMIC_FLAG_INIT ATOMIC_FLAG_INIT
 
 #define SOUNDIO_ATOMIC_LOAD_BOOL SOUNDIO_ATOMIC_LOAD_

--- a/src/atomics.h
+++ b/src/atomics.h
@@ -8,10 +8,23 @@
 #ifndef SOUNDIO_ATOMICS_H
 #define SOUNDIO_ATOMICS_H
 
+#ifdef __cplusplus
+#define SOUNDIO_USE_CPP_ATOMICS
+#else // ifdef __cplusplus
+
+#ifdef _MSC_VER
+#define SOUNDIO_USE_MSVC_NATIVE_C_ATOMICS
+#else
+#define SOUNDIO_USE_GNU_ATOMICS
+#endif // ifdef _MSC_VER
+
+#endif // ifdef __cplusplus
+
+
 // Simple wrappers around atomic values so that the compiler will catch it if
 // I accidentally use operators such as +, -, += on them.
 
-#ifdef __cplusplus
+#ifdef SOUNDIO_USE_CPP_ATOMICS
 
 #include <atomic>
 
@@ -35,15 +48,38 @@ struct SoundIoAtomicULong {
     std::atomic<unsigned long> x;
 };
 
-#define SOUNDIO_ATOMIC_LOAD(a) (a.x.load())
-#define SOUNDIO_ATOMIC_FETCH_ADD(a, delta) (a.x.fetch_add(delta))
-#define SOUNDIO_ATOMIC_STORE(a, value) (a.x.store(value))
-#define SOUNDIO_ATOMIC_EXCHANGE(a, value) (a.x.exchange(value))
+#define SOUNDIO_ATOMIC_LOAD_(a) (a.x.load())
+#define SOUNDIO_ATOMIC_FETCH_ADD_(a, delta) (a.x.fetch_add(delta))
+#define SOUNDIO_ATOMIC_STORE_(a, value) (a.x.store(value))
+#define SOUNDIO_ATOMIC_EXCHANGE_(a, value) (a.x.exchange(value))
+
+#define SOUNDIO_ATOMIC_LOAD_BOOL SOUNDIO_ATOMIC_LOAD_
+#define SOUNDIO_ATOMIC_STORE_BOOL SOUNDIO_ATOMIC_STORE_
+#define SOUNDIO_ATOMIC_FETCH_ADD_BOOL SOUNDIO_ATOMIC_FETCH_ADD_
+#define SOUNDIO_ATOMIC_EXCHANGE_BOOL SOUNDIO_ATOMIC_EXCHANGE_
+
+#define SOUNDIO_ATOMIC_LOAD_INT SOUNDIO_ATOMIC_LOAD_
+#define SOUNDIO_ATOMIC_STORE_INT SOUNDIO_ATOMIC_STORE_
+#define SOUNDIO_ATOMIC_FETCH_ADD_INT SOUNDIO_ATOMIC_FETCH_ADD_
+#define SOUNDIO_ATOMIC_EXCHANGE_INT SOUNDIO_ATOMIC_EXCHANGE_
+
+#define SOUNDIO_ATOMIC_LOAD_LONG SOUNDIO_ATOMIC_LOAD_
+#define SOUNDIO_ATOMIC_STORE_LONG SOUNDIO_ATOMIC_STORE_
+#define SOUNDIO_ATOMIC_FETCH_ADD_LONG SOUNDIO_ATOMIC_FETCH_ADD_
+#define SOUNDIO_ATOMIC_EXCHANGE_LONG SOUNDIO_ATOMIC_EXCHANGE_
+
+#define SOUNDIO_ATOMIC_LOAD_ULONG SOUNDIO_ATOMIC_LOAD_
+#define SOUNDIO_ATOMIC_STORE_ULONG SOUNDIO_ATOMIC_STORE_
+#define SOUNDIO_ATOMIC_FETCH_ADD_ULONG SOUNDIO_ATOMIC_FETCH_ADD_
+#define SOUNDIO_ATOMIC_EXCHANGE_ULONG SOUNDIO_ATOMIC_EXCHANGE_
+
 #define SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(a) (a.x.test_and_set())
 #define SOUNDIO_ATOMIC_FLAG_CLEAR(a) (a.x.clear())
 #define SOUNDIO_ATOMIC_FLAG_INIT ATOMIC_FLAG_INIT
 
-#else
+#endif
+
+#ifdef SOUNDIO_USE_GNU_ATOMICS
 
 #include <stdatomic.h>
 
@@ -67,14 +103,141 @@ struct SoundIoAtomicULong {
     atomic_ulong x;
 };
 
-#define SOUNDIO_ATOMIC_LOAD(a) atomic_load(&a.x)
-#define SOUNDIO_ATOMIC_FETCH_ADD(a, delta) atomic_fetch_add(&a.x, delta)
-#define SOUNDIO_ATOMIC_STORE(a, value) atomic_store(&a.x, value)
-#define SOUNDIO_ATOMIC_EXCHANGE(a, value) atomic_exchange(&a.x, value)
-#define SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(a) atomic_flag_test_and_set(&a.x)
-#define SOUNDIO_ATOMIC_FLAG_CLEAR(a) atomic_flag_clear(&a.x)
+#define SOUNDIO_ATOMIC_LOAD_(a) atomic_load(&a.x)
+#define SOUNDIO_ATOMIC_FETCH_ADD_(a, delta) atomic_fetch_add(&a.x, delta)
+#define SOUNDIO_ATOMIC_STORE_(a, value) atomic_store(&a.x, value)
+#define SOUNDIO_ATOMIC_EXCHANGE_(a, value) atomic_exchange(&a.x, value)
+#define SOUNDIO_ATOMIC_FLAG_TEST_AND_SET_(a) atomic_flag_test_and_set(&a.x)
+#define SOUNDIO_ATOMIC_FLAG_CLEAR_(a) atomic_flag_clear(&a.x)
 #define SOUNDIO_ATOMIC_FLAG_INIT ATOMIC_FLAG_INIT
 
-#endif
+#define SOUNDIO_ATOMIC_LOAD_BOOL SOUNDIO_ATOMIC_LOAD_
+#define SOUNDIO_ATOMIC_STORE_BOOL SOUNDIO_ATOMIC_STORE_
+#define SOUNDIO_ATOMIC_FETCH_ADD_BOOL SOUNDIO_ATOMIC_FETCH_ADD_
+#define SOUNDIO_ATOMIC_EXCHANGE_BOOL SOUNDIO_ATOMIC_EXCHANGE_
+
+#define SOUNDIO_ATOMIC_LOAD_INT SOUNDIO_ATOMIC_LOAD_
+#define SOUNDIO_ATOMIC_STORE_INT SOUNDIO_ATOMIC_STORE_
+#define SOUNDIO_ATOMIC_FETCH_ADD_INT SOUNDIO_ATOMIC_FETCH_ADD_
+#define SOUNDIO_ATOMIC_EXCHANGE_INT SOUNDIO_ATOMIC_EXCHANGE_
+
+#define SOUNDIO_ATOMIC_LOAD_LONG SOUNDIO_ATOMIC_LOAD_
+#define SOUNDIO_ATOMIC_STORE_LONG SOUNDIO_ATOMIC_STORE_
+#define SOUNDIO_ATOMIC_FETCH_ADD_LONG SOUNDIO_ATOMIC_FETCH_ADD_
+#define SOUNDIO_ATOMIC_EXCHANGE_LONG SOUNDIO_ATOMIC_EXCHANGE_
+
+#define SOUNDIO_ATOMIC_LOAD_ULONG SOUNDIO_ATOMIC_LOAD_
+#define SOUNDIO_ATOMIC_STORE_ULONG SOUNDIO_ATOMIC_STORE_
+#define SOUNDIO_ATOMIC_FETCH_ADD_ULONG SOUNDIO_ATOMIC_FETCH_ADD_
+#define SOUNDIO_ATOMIC_EXCHANGE_ULONG SOUNDIO_ATOMIC_EXCHANGE_
 
 #endif
+
+#ifdef SOUNDIO_USE_MSVC_NATIVE_C_ATOMICS
+// When building for native msvc, we can leverage builtin atomics.
+
+#ifdef _WIN64
+#define SOUNDIO_MSVC_POINTER_SIZE 8
+#else
+#define SOUNDIO_MSVC_POINTER_SIZE 4
+#endif
+
+struct SoundIoAtomicLong {
+    long x;
+};
+
+struct SoundIoAtomicInt {
+    int x;
+};
+
+struct SoundIoAtomicBool {
+    char x;
+};
+
+struct SoundIoAtomicFlag {
+    long x;
+};
+
+struct SoundIoAtomicULong { 
+    unsigned long x;
+};
+
+// When sticking to raw C and msvc, we rely on MSVC compiler intrinsics and are unable to
+// Automatically deduce types at compile time. Must use the correct macro for the correct function.
+//
+// No headers needed. We use _Interlocked* family of compiler intrinsics. 
+// Implementation referenced from the fantastic turf library's `atomic_msvc.h`
+
+// How the living hell is it that to this day and age. msvc does not support typeof which both clang 
+// and gcc support.
+//
+// guess this is why c11 in msvc can't implement stdatomic.h right now
+#define SOUNDIO_ATOMIC_LOAD_BOOL(a) (char) *((volatile char*) &(a.x))
+#define SOUNDIO_ATOMIC_STORE_BOOL(a, value) (*((volatile char*) &(a.x))) = value
+#define SOUNDIO_ATOMIC_FETCH_ADD_BOOL(a, delta) _InterlockedExchangeAdd8((volatile char*) (&a.x), delta) 
+#define SOUNDIO_ATOMIC_EXCHANGE_BOOL(a, value) _InterlockedExchange8((volatile char*) (&a.x), value)
+
+#define SOUNDIO_ATOMIC_LOAD_INT(a) (int) *((volatile int*) &(a.x))
+#define SOUNDIO_ATOMIC_STORE_INT(a, value) *((volatile int*) &(a.x)) = value
+#define SOUNDIO_ATOMIC_FETCH_ADD_INT(a, delta) _InterlockedExchangeAdd((volatile LONG*) (&a.x), delta)
+#define SOUNDIO_ATOMIC_EXCHANGE_INT(a, value) _InterlockedExchange((volatile LONG*) (&a.x), value)
+
+#define SOUNDIO_ATOMIC_LOAD_LONG(a) SoundIoMSVCLoadLong(&a)
+#define SOUNDIO_ATOMIC_STORE_LONG(a, value) SoundIoMSVCStoreLong((struct SoundIoAtomicLong*) &a, value)
+#define SOUNDIO_ATOMIC_FETCH_ADD_LONG(a, delta) _InterlockedExchangeAdd64((long*) (&a.x), delta)
+#define SOUNDIO_ATOMIC_EXCHANGE_LONG(a, value) _InterlockedExchange64((long*) (&a.x), delta)
+
+#define SOUNDIO_ATOMIC_LOAD_ULONG(a) SoundIoMSVCLoadLong(&a)
+#define SOUNDIO_ATOMIC_STORE_ULONG(a, value) SoundIoMSVCStoreLong((struct SoundIoAtomicULong*) &a, value)
+#define SOUNDIO_ATOMIC_FETCH_ADD_ULONG(a, delta) _InterlockedExchangeAdd64((volatile long*) (&a.x), delta)
+#define SOUNDIO_ATOMIC_EXCHANGE_ULONG(a, value) _InterlockedExchange64((volatile long*) (&a.x), delta)
+
+#define SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(a) _interlockedbittestandset(&a.x, 0)
+#define SOUNDIO_ATOMIC_FLAG_CLEAR(a) _interlockedbittestandreset(&a.x, 0)
+#define SOUNDIO_ATOMIC_FLAG_INIT {1}
+
+#define SOUNDIO_ATOMIC_LOAD(a) error
+#define SOUNDIO_ATOMIC_FETCH_ADD(a, delta) error
+#define SOUNDIO_ATOMIC_STORE(a, value) error
+#define SOUNDIO_ATOMIC_EXCHANGE(a, value) error
+
+static long SoundIoMSVCLoadLong(struct SoundIoAtomicLong* a)
+{
+#if SOUNDIO_MSVC_POINTER_SIZE == 8
+    return ((volatile struct SoundIoAtomicLong*) a)->x;
+#else
+
+   uint64_t result;
+    __asm {
+        mov esi, object;
+        mov ebx, eax;
+        mov ecx, edx;
+        lock cmpxchg8b [esi];
+        mov dword ptr result, eax;
+        mov dword ptr result[4], edx;
+    }
+    return result;
+
+#endif
+}
+
+static void SoundIoMSVCStoreLong(struct SoundIoAtomicLong* a, long value)
+{
+#if SOUNDIO_MSVC_POINTER_SIZE == 8
+    ((volatile struct SoundIoAtomicLong*) a)->x = value;
+#else
+    __asm {
+        mov esi, object;
+        mov ebx, dword ptr value;
+        mov ecx, dword ptr value[4];
+    retry:
+        cmpxchg8b [esi];
+        jne retry;
+    }
+#endif
+}
+
+#endif
+
+#endif //SOUNDIO_ATOMICS_H
+

--- a/src/channel_layout.c
+++ b/src/channel_layout.c
@@ -456,7 +456,7 @@ enum SoundIoChannelId soundio_parse_channel_id(const char *str, int str_len) {
             const char *alias = channel_names[id][i];
             if (!alias)
                 break;
-            int alias_len = strlen(alias);
+            int alias_len = (int) strlen(alias);
             if (soundio_streql(alias, alias_len, str, str_len))
                 return (enum SoundIoChannelId)id;
         }

--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -10,6 +10,11 @@
 
 #include <assert.h>
 
+#include "AvailabilityMacros.h"
+#ifndef MAC_OS_VERSION_12_0
+#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
+#endif
+
 static const int OUTPUT_ELEMENT = 0;
 static const int INPUT_ELEMENT = 1;
 
@@ -17,77 +22,77 @@ static AudioObjectPropertyAddress device_listen_props[] = {
     {
         kAudioDevicePropertyDeviceHasChanged,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioObjectPropertyName,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyDeviceUID,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyStreamConfiguration,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyStreamConfiguration,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyPreferredChannelLayout,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyPreferredChannelLayout,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyNominalSampleRate,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyNominalSampleRate,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyAvailableNominalSampleRates,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyAvailableNominalSampleRates,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyBufferFrameSize,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyBufferFrameSize,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyBufferFrameSizeRange,
         kAudioObjectPropertyScopeInput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
     {
         kAudioDevicePropertyBufferFrameSizeRange,
         kAudioObjectPropertyScopeOutput,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     },
 };
 
@@ -141,7 +146,7 @@ static void destroy_ca(struct SoundIoPrivate *si) {
     AudioObjectPropertyAddress prop_address = {
         kAudioHardwarePropertyDevices,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
     AudioObjectRemovePropertyListener(kAudioObjectSystemObject, &prop_address, on_devices_changed, si);
 
@@ -434,7 +439,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
     AudioObjectPropertyAddress prop_address = {
         kAudioHardwarePropertyDevices,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
 
     if ((os_err = AudioObjectGetPropertyDataSize(kAudioObjectSystemObject,
@@ -503,7 +508,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
         prop_address.mSelector = kAudioObjectPropertyName;
         prop_address.mScope = kAudioObjectPropertyScopeGlobal;
-        prop_address.mElement = kAudioObjectPropertyElementMaster;
+        prop_address.mElement = kAudioObjectPropertyElementMain;
         io_size = sizeof(CFStringRef);
         if (rd.string_ref) {
             CFRelease(rd.string_ref);
@@ -525,7 +530,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
         prop_address.mSelector = kAudioDevicePropertyDeviceUID;
         prop_address.mScope = kAudioObjectPropertyScopeGlobal;
-        prop_address.mElement = kAudioObjectPropertyElementMaster;
+        prop_address.mElement = kAudioObjectPropertyElementMain;
         io_size = sizeof(CFStringRef);
         if (rd.string_ref) {
             CFRelease(rd.string_ref);
@@ -552,7 +557,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             io_size = 0;
             prop_address.mSelector = kAudioDevicePropertyStreamConfiguration;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             if ((os_err = AudioObjectGetPropertyDataSize(device_id, &prop_address, 0, NULL, &io_size))) {
                 deinit_refresh_devices(&rd);
                 return SoundIoErrorOpeningDevice;
@@ -603,7 +608,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyPreferredChannelLayout;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             if (!(os_err = AudioObjectGetPropertyDataSize(device_id, &prop_address,
                 0, NULL, &io_size)))
             {
@@ -643,7 +648,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyNominalSampleRate;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             io_size = sizeof(double);
             double value;
             if ((os_err = AudioObjectGetPropertyData(device_id, &prop_address, 0, NULL,
@@ -669,7 +674,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
             } else {
                 prop_address.mSelector = kAudioDevicePropertyAvailableNominalSampleRates;
                 prop_address.mScope = aim_to_scope(aim);
-                prop_address.mElement = kAudioObjectPropertyElementMaster;
+                prop_address.mElement = kAudioObjectPropertyElementMain;
                 if ((os_err = AudioObjectGetPropertyDataSize(device_id, &prop_address, 0, NULL,
                     &io_size)))
                 {
@@ -715,7 +720,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyBufferFrameSize;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             io_size = sizeof(UInt32);
             UInt32 buffer_frame_size;
             if ((os_err = AudioObjectGetPropertyData(device_id, &prop_address, 0, NULL,
@@ -729,7 +734,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyBufferFrameSizeRange;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             io_size = sizeof(AudioValueRange);
             AudioValueRange avr;
             if ((os_err = AudioObjectGetPropertyData(device_id, &prop_address, 0, NULL,
@@ -743,7 +748,7 @@ static int refresh_devices(struct SoundIoPrivate *si) {
 
             prop_address.mSelector = kAudioDevicePropertyLatency;
             prop_address.mScope = aim_to_scope(aim);
-            prop_address.mElement = kAudioObjectPropertyElementMaster;
+            prop_address.mElement = kAudioObjectPropertyElementMain;
             io_size = sizeof(UInt32);
             if ((os_err = AudioObjectGetPropertyData(device_id, &prop_address, 0, NULL,
                 &io_size, &dca->latency_frames)))
@@ -894,7 +899,7 @@ static void outstream_destroy_ca(struct SoundIoPrivate *si, struct SoundIoOutStr
     AudioObjectPropertyAddress prop_address = {
         kAudioDeviceProcessorOverload,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
     AudioObjectRemovePropertyListener(dca->device_id, &prop_address, on_outstream_device_overload, os);
 
@@ -1151,7 +1156,7 @@ static void instream_destroy_ca(struct SoundIoPrivate *si, struct SoundIoInStrea
     AudioObjectPropertyAddress prop_address = {
         kAudioDeviceProcessorOverload,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
     AudioObjectRemovePropertyListener(dca->device_id, &prop_address, on_instream_device_overload, is);
 
@@ -1230,7 +1235,7 @@ static int instream_open_ca(struct SoundIoPrivate *si, struct SoundIoInStreamPri
     AudioObjectPropertyAddress prop_address;
     prop_address.mSelector = kAudioDevicePropertyStreamConfiguration;
     prop_address.mScope = kAudioObjectPropertyScopeInput;
-    prop_address.mElement = kAudioObjectPropertyElementMaster;
+    prop_address.mElement = kAudioObjectPropertyElementMain;
     io_size = 0;
     if ((os_err = AudioObjectGetPropertyDataSize(dca->device_id, &prop_address,
         0, NULL, &io_size)))
@@ -1437,7 +1442,7 @@ int soundio_coreaudio_init(struct SoundIoPrivate *si) {
     AudioObjectPropertyAddress prop_address = {
         kAudioHardwarePropertyDevices,
         kAudioObjectPropertyScopeGlobal,
-        kAudioObjectPropertyElementMaster
+        kAudioObjectPropertyElementMain
     };
     if ((err = AudioObjectAddPropertyListener(kAudioObjectSystemObject, &prop_address,
         on_devices_changed, si)))

--- a/src/os.c
+++ b/src/os.c
@@ -450,7 +450,7 @@ void soundio_os_cond_timed_wait(struct SoundIoOsCond *cond,
         target_cs = &cond->default_cs_id;
         EnterCriticalSection(&cond->default_cs_id);
     }
-    DWORD ms = seconds * 1000.0;
+    DWORD ms = (DWORD) (seconds * 1000.0);
     SleepConditionVariableCS(&cond->id, target_cs, ms);
     if (!locked_mutex)
         LeaveCriticalSection(&cond->default_cs_id);
@@ -585,7 +585,7 @@ int soundio_os_init(void) {
     if (!pending)
         return 0;
 
-    if ((err = internal_init()))
+    if ((err = internal_init()) != 0)
         return err;
 
     if (!InitOnceComplete(&win32_init_once, INIT_ONCE_ASYNC, NULL))
@@ -610,8 +610,9 @@ int soundio_os_page_size(void) {
 }
 
 static inline size_t ceil_dbl_to_size_t(double x) {
-    const double truncation = (size_t)x;
-    return truncation + (truncation < x);
+    const size_t trunc = (size_t)x;
+    const double truncation = (double)trunc;
+    return (size_t) (truncation + (truncation < x));
 }
 
 int soundio_os_init_mirrored_memory(struct SoundIoOsMirroredMemory *mem, size_t requested_capacity) {
@@ -619,7 +620,7 @@ int soundio_os_init_mirrored_memory(struct SoundIoOsMirroredMemory *mem, size_t 
 
 #if defined(SOUNDIO_OS_WINDOWS)
     BOOL ok;
-    HANDLE hMapFile = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, actual_capacity * 2, NULL);
+    HANDLE hMapFile = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, (DWORD)(actual_capacity * 2), NULL);
     if (!hMapFile)
         return SoundIoErrorNoMem;
 

--- a/src/ring_buffer.c
+++ b/src/ring_buffer.c
@@ -12,6 +12,9 @@
 #include <stdlib.h>
 
 struct SoundIoRingBuffer *soundio_ring_buffer_create(struct SoundIo *soundio, int requested_capacity) {
+    (void)soundio;
+    (void)requested_capacity;
+
     struct SoundIoRingBuffer *rb = ALLOCATE(struct SoundIoRingBuffer, 1);
 
     assert(requested_capacity > 0);
@@ -43,30 +46,30 @@ int soundio_ring_buffer_capacity(struct SoundIoRingBuffer *rb) {
 }
 
 char *soundio_ring_buffer_write_ptr(struct SoundIoRingBuffer *rb) {
-    unsigned long write_offset = SOUNDIO_ATOMIC_LOAD(rb->write_offset);
+    unsigned long write_offset = SOUNDIO_ATOMIC_LOAD_ULONG(rb->write_offset);
     return rb->mem.address + (write_offset % rb->capacity);
 }
 
 void soundio_ring_buffer_advance_write_ptr(struct SoundIoRingBuffer *rb, int count) {
-    SOUNDIO_ATOMIC_FETCH_ADD(rb->write_offset, count);
+    SOUNDIO_ATOMIC_FETCH_ADD_ULONG(rb->write_offset, count);
     assert(soundio_ring_buffer_fill_count(rb) >= 0);
 }
 
 char *soundio_ring_buffer_read_ptr(struct SoundIoRingBuffer *rb) {
-    unsigned long read_offset = SOUNDIO_ATOMIC_LOAD(rb->read_offset);
+    unsigned long read_offset = SOUNDIO_ATOMIC_LOAD_ULONG(rb->read_offset);
     return rb->mem.address + (read_offset % rb->capacity);
 }
 
 void soundio_ring_buffer_advance_read_ptr(struct SoundIoRingBuffer *rb, int count) {
-    SOUNDIO_ATOMIC_FETCH_ADD(rb->read_offset, count);
+    SOUNDIO_ATOMIC_FETCH_ADD_ULONG(rb->read_offset, count);
     assert(soundio_ring_buffer_fill_count(rb) >= 0);
 }
 
 int soundio_ring_buffer_fill_count(struct SoundIoRingBuffer *rb) {
     // Whichever offset we load first might have a smaller value. So we load
     // the read_offset first.
-    unsigned long read_offset = SOUNDIO_ATOMIC_LOAD(rb->read_offset);
-    unsigned long write_offset = SOUNDIO_ATOMIC_LOAD(rb->write_offset);
+    unsigned long read_offset = SOUNDIO_ATOMIC_LOAD_ULONG(rb->read_offset);
+    unsigned long write_offset = SOUNDIO_ATOMIC_LOAD_ULONG(rb->write_offset);
     int count = write_offset - read_offset;
     assert(count >= 0);
     assert(count <= rb->capacity);
@@ -78,16 +81,16 @@ int soundio_ring_buffer_free_count(struct SoundIoRingBuffer *rb) {
 }
 
 void soundio_ring_buffer_clear(struct SoundIoRingBuffer *rb) {
-    unsigned long read_offset = SOUNDIO_ATOMIC_LOAD(rb->read_offset);
-    SOUNDIO_ATOMIC_STORE(rb->write_offset, read_offset);
+    unsigned long read_offset = SOUNDIO_ATOMIC_LOAD_ULONG(rb->read_offset);
+    SOUNDIO_ATOMIC_STORE_ULONG(rb->write_offset, read_offset);
 }
 
 int soundio_ring_buffer_init(struct SoundIoRingBuffer *rb, int requested_capacity) {
     int err;
     if ((err = soundio_os_init_mirrored_memory(&rb->mem, requested_capacity)))
         return err;
-    SOUNDIO_ATOMIC_STORE(rb->write_offset, 0);
-    SOUNDIO_ATOMIC_STORE(rb->read_offset, 0);
+    SOUNDIO_ATOMIC_STORE_ULONG(rb->write_offset, 0);
+    SOUNDIO_ATOMIC_STORE_ULONG(rb->read_offset, 0);
     rb->capacity = rb->mem.capacity;
 
     return 0;

--- a/src/soundio.c
+++ b/src/soundio.c
@@ -170,10 +170,17 @@ void soundio_destroy(struct SoundIo *soundio) {
     free(si);
 }
 
-static void do_nothing_cb(struct SoundIo *soundio) { }
-static void default_msg_callback(const char *msg) { }
+static void do_nothing_cb(struct SoundIo *soundio) {
+    (void)soundio;
+}
+
+static void default_msg_callback(const char *msg) { 
+    (void)msg;
+}
 
 static void default_backend_disconnect_cb(struct SoundIo *soundio, int err) {
+    (void)soundio;
+
     soundio_panic("libsoundio: backend disconnected: %s", soundio_strerror(err));
 }
 
@@ -458,10 +465,13 @@ int soundio_outstream_end_write(struct SoundIoOutStream *outstream) {
 }
 
 static void default_outstream_error_callback(struct SoundIoOutStream *os, int err) {
+    (void)os;
     soundio_panic("libsoundio: %s", soundio_strerror(err));
 }
 
-static void default_underflow_callback(struct SoundIoOutStream *outstream) { }
+static void default_underflow_callback(struct SoundIoOutStream *outstream) {
+    (void)outstream;
+}
 
 struct SoundIoOutStream *soundio_outstream_create(struct SoundIoDevice *device) {
     struct SoundIoOutStreamPrivate *os = ALLOCATE(struct SoundIoOutStreamPrivate, 1);
@@ -565,14 +575,17 @@ int soundio_outstream_set_volume(struct SoundIoOutStream *outstream, double volu
     struct SoundIo *soundio = outstream->device->soundio;
     struct SoundIoPrivate *si = (struct SoundIoPrivate *)soundio;
     struct SoundIoOutStreamPrivate *os = (struct SoundIoOutStreamPrivate *)outstream;
-    return si->outstream_set_volume(si, os, volume);
+    return si->outstream_set_volume(si, os, (float)volume);
 }
 
 static void default_instream_error_callback(struct SoundIoInStream *is, int err) {
+    (void)is;
     soundio_panic("libsoundio: %s", soundio_strerror(err));
 }
 
-static void default_overflow_callback(struct SoundIoInStream *instream) { }
+static void default_overflow_callback(struct SoundIoInStream *instream) { 
+    (void)instream;
+}
 
 struct SoundIoInStream *soundio_instream_create(struct SoundIoDevice *device) {
     struct SoundIoInStreamPrivate *is = ALLOCATE(struct SoundIoInStreamPrivate, 1);
@@ -702,10 +715,12 @@ bool soundio_have_backend(enum SoundIoBackend backend) {
 }
 
 int soundio_backend_count(struct SoundIo *soundio) {
+    (void)soundio;
     return ARRAY_LENGTH(available_backends);
 }
 
 enum SoundIoBackend soundio_get_backend(struct SoundIo *soundio, int index) {
+    (void)soundio;
     return available_backends[index];
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -86,11 +86,12 @@ static inline bool soundio_streql(const char *str1, int str1_len, const char *st
 
 static inline int ceil_dbl_to_int(double x) {
     const double truncation = (int)x;
-    return truncation + (truncation < x);
+    return (int)(truncation + (truncation < x));
 }
 
 static inline double ceil_dbl(double x) {
-    const double truncation = (long long) x;
+    const long long truncated = (long long)x;
+    const double truncation = (double) truncated;
     const double ceiling = truncation + (truncation < x);
     return ceiling;
 }

--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -30,47 +30,52 @@
 #define E_NOTFOUND 0x80070490
 #endif //E_NOTFOUND
 
+#ifndef _MSC_VER
+#define SOUNDIO_WASAPI_SPEC static
+#else
+#define SOUNDIO_WASAPI_SPEC
+#endif
 // And some GUID are never implemented (Ignoring the INITGUID define)
-static const CLSID CLSID_MMDeviceEnumerator = {
+SOUNDIO_WASAPI_SPEC const CLSID CLSID_MMDeviceEnumerator = {
     0xbcde0395, 0xe52f, 0x467c, {0x8e, 0x3d, 0xc4, 0x57, 0x92, 0x91, 0x69, 0x2e}
 };
-static const IID   IID_IMMDeviceEnumerator   = {
+SOUNDIO_WASAPI_SPEC const IID   IID_IMMDeviceEnumerator   = {
     //MIDL_INTERFACE("A95664D2-9614-4F35-A746-DE8DB63617E6")
     0xa95664d2, 0x9614, 0x4f35, {0xa7, 0x46, 0xde, 0x8d, 0xb6, 0x36, 0x17, 0xe6}
 };
-static const IID   IID_IMMNotificationClient = {
+SOUNDIO_WASAPI_SPEC const IID   IID_IMMNotificationClient = {
     //MIDL_INTERFACE("7991EEC9-7E89-4D85-8390-6C703CEC60C0")
     0x7991eec9, 0x7e89, 0x4d85, {0x83, 0x90, 0x6c, 0x70, 0x3c, 0xec, 0x60, 0xc0}
 };
-static const IID   IID_IAudioClient = {
+SOUNDIO_WASAPI_SPEC const IID   IID_IAudioClient = {
     //MIDL_INTERFACE("1CB9AD4C-DBFA-4c32-B178-C2F568A703B2")
     0x1cb9ad4c, 0xdbfa, 0x4c32, {0xb1, 0x78, 0xc2, 0xf5, 0x68, 0xa7, 0x03, 0xb2}
 };
-static const IID   IID_IAudioRenderClient    = {
+SOUNDIO_WASAPI_SPEC const IID   IID_IAudioRenderClient    = {
     //MIDL_INTERFACE("F294ACFC-3146-4483-A7BF-ADDCA7C260E2")
     0xf294acfc, 0x3146, 0x4483, {0xa7, 0xbf, 0xad, 0xdc, 0xa7, 0xc2, 0x60, 0xe2}
 };
-static const IID   IID_IAudioSessionControl  = {
+SOUNDIO_WASAPI_SPEC const IID   IID_IAudioSessionControl  = {
     //MIDL_INTERFACE("F4B1A599-7266-4319-A8CA-E70ACB11E8CD")
     0xf4b1a599, 0x7266, 0x4319, {0xa8, 0xca, 0xe7, 0x0a, 0xcb, 0x11, 0xe8, 0xcd}
 };
-static const IID   IID_IAudioSessionEvents   = {
+SOUNDIO_WASAPI_SPEC const IID   IID_IAudioSessionEvents   = {
     //MIDL_INTERFACE("24918ACC-64B3-37C1-8CA9-74A66E9957A8")
     0x24918acc, 0x64b3, 0x37c1, {0x8c, 0xa9, 0x74, 0xa6, 0x6e, 0x99, 0x57, 0xa8}
 };
-static const IID IID_IMMEndpoint = {
+SOUNDIO_WASAPI_SPEC const IID IID_IMMEndpoint = {
     //MIDL_INTERFACE("1BE09788-6894-4089-8586-9A2A6C265AC5")
     0x1be09788, 0x6894, 0x4089, {0x85, 0x86, 0x9a, 0x2a, 0x6c, 0x26, 0x5a, 0xc5}
 };
-static const IID IID_IAudioClockAdjustment = {
+SOUNDIO_WASAPI_SPEC const IID IID_IAudioClockAdjustment = {
     //MIDL_INTERFACE("f6e4c0a0-46d9-4fb8-be21-57a3ef2b626c")
     0xf6e4c0a0, 0x46d9, 0x4fb8, {0xbe, 0x21, 0x57, 0xa3, 0xef, 0x2b, 0x62, 0x6c}
 };
-static const IID IID_IAudioCaptureClient = {
+SOUNDIO_WASAPI_SPEC const IID IID_IAudioCaptureClient = {
     //MIDL_INTERFACE("C8ADBD64-E71E-48a0-A4DE-185C395CD317")
     0xc8adbd64, 0xe71e, 0x48a0, {0xa4, 0xde, 0x18, 0x5c, 0x39, 0x5c, 0xd3, 0x17}
 };
-static const IID IID_ISimpleAudioVolume = {
+SOUNDIO_WASAPI_SPEC const IID IID_ISimpleAudioVolume = {
     //MIDL_INTERFACE("87ce5498-68d6-44e5-9215-6da47ef883d8")
     0x87ce5498, 0x68d6, 0x44e5,{ 0x92, 0x15, 0x6d, 0xa4, 0x7e, 0xf8, 0x83, 0xd8 }
 };
@@ -1193,6 +1198,7 @@ static void force_device_scan_wasapi(struct SoundIoPrivate *si) {
 }
 
 static void outstream_thread_deinit(struct SoundIoPrivate *si, struct SoundIoOutStreamPrivate *os) {
+    (void)si;
     struct SoundIoOutStreamWasapi *osw = &os->backend_data.wasapi;
 
     if (osw->audio_volume_control)
@@ -1441,7 +1447,7 @@ static void outstream_shared_run(struct SoundIoOutStreamPrivate *os) {
             reset_buffer = true;
         }
         if (!SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(osw->pause_resume_flag)) {
-            bool pause = SOUNDIO_ATOMIC_LOAD(osw->desired_pause_state);
+            bool pause = SOUNDIO_ATOMIC_LOAD_BOOL(osw->desired_pause_state);
             if (pause && !osw->is_paused) {
                 if (FAILED(hr = IAudioClient_Stop(osw->audio_client))) {
                     outstream->error_callback(outstream, SoundIoErrorStreaming);
@@ -1489,7 +1495,7 @@ static void outstream_raw_run(struct SoundIoOutStreamPrivate *os) {
         if (!SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(osw->thread_exit_flag))
             return;
         if (!SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(osw->pause_resume_flag)) {
-            bool pause = SOUNDIO_ATOMIC_LOAD(osw->desired_pause_state);
+            bool pause = SOUNDIO_ATOMIC_LOAD_BOOL(osw->desired_pause_state);
             if (pause && !osw->is_paused) {
                 if (FAILED(hr = IAudioClient_Stop(osw->audio_client))) {
                     outstream->error_callback(outstream, SoundIoErrorStreaming);
@@ -1560,7 +1566,7 @@ static int outstream_open_wasapi(struct SoundIoPrivate *si, struct SoundIoOutStr
 
     SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(osw->pause_resume_flag);
     SOUNDIO_ATOMIC_FLAG_TEST_AND_SET(osw->clear_buffer_flag);
-    SOUNDIO_ATOMIC_STORE(osw->desired_pause_state, false);
+    SOUNDIO_ATOMIC_STORE_BOOL(osw->desired_pause_state, false);
 
     // All the COM functions are supposed to be called from the same thread. libsoundio API does not
     // restrict the calling thread context in this way. Furthermore, the user might have called
@@ -1617,7 +1623,7 @@ static int outstream_open_wasapi(struct SoundIoPrivate *si, struct SoundIoOutStr
 static int outstream_pause_wasapi(struct SoundIoPrivate *si, struct SoundIoOutStreamPrivate *os, bool pause) {
     struct SoundIoOutStreamWasapi *osw = &os->backend_data.wasapi;
 
-    SOUNDIO_ATOMIC_STORE(osw->desired_pause_state, pause);
+    SOUNDIO_ATOMIC_STORE_BOOL(osw->desired_pause_state, pause);
     SOUNDIO_ATOMIC_FLAG_CLEAR(osw->pause_resume_flag);
     SetEvent(osw->h_event);
 

--- a/test/backend_disconnect_recover.c
+++ b/test/backend_disconnect_recover.c
@@ -12,12 +12,20 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+
+#ifndef _MSC_VER
 #include <unistd.h>
 
 __attribute__ ((cold))
 __attribute__ ((noreturn))
 __attribute__ ((format (printf, 1, 2)))
 static void panic(const char *format, ...) {
+#else
+#include <Windows.h>
+#define sleep(x) Sleep(x * 1000)
+
+__declspec(noreturn) static void panic(const char *format, ...) {
+#endif
     va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);

--- a/test/latency.c
+++ b/test/latency.c
@@ -24,19 +24,19 @@ static void write_sample_s16ne(char *ptr, double sample) {
     int16_t *buf = (int16_t *)ptr;
     double range = (double)INT16_MAX - (double)INT16_MIN;
     double val = sample * range / 2.0;
-    *buf = val;
+    *buf = (int16_t) val;
 }
 
 static void write_sample_s32ne(char *ptr, double sample) {
     int32_t *buf = (int32_t *)ptr;
     double range = (double)INT32_MAX - (double)INT32_MIN;
     double val = sample * range / 2.0;
-    *buf = val;
+    *buf = (int32_t) val;
 }
 
 static void write_sample_float32ne(char *ptr, double sample) {
     float *buf = (float *)ptr;
-    *buf = sample;
+    *buf = (float) sample;
 }
 
 static void write_sample_float64ne(char *ptr, double sample) {
@@ -67,6 +67,10 @@ static void write_time(struct SoundIoOutStream *outstream, double extra) {
 }
 
 static void write_callback(struct SoundIoOutStream *outstream, int frame_count_min, int frame_count_max) {
+    (void)outstream;
+    (void)frame_count_min;
+    (void)frame_count_max;
+
     double float_sample_rate = outstream->sample_rate;
     double seconds_per_frame = 1.0f / float_sample_rate;
     struct SoundIoChannelArea *areas;
@@ -91,14 +95,14 @@ static void write_callback(struct SoundIoOutStream *outstream, int frame_count_m
             double sample;
             if (frames_until_pulse <= 0) {
                 if (pulse_frames_left == -1) {
-                    pulse_frames_left = 0.25 * float_sample_rate;
+                    pulse_frames_left = (int) (0.25 * float_sample_rate);
                     write_time(outstream, seconds_per_frame * frame); // announce beep start
                 }
                 if (pulse_frames_left > 0) {
                     pulse_frames_left -= 1;
-                    sample = sinf((seconds_offset + frame * seconds_per_frame) * radians_per_second);
+                    sample = sinf((float) ((seconds_offset + frame * seconds_per_frame) * radians_per_second));
                 } else {
-                    frames_until_pulse = (0.5 + (rand() / (double)RAND_MAX) * 2.0) * float_sample_rate;
+                    frames_until_pulse = (int) ((0.5 + (rand() / (double)RAND_MAX) * 2.0) * float_sample_rate);
                     pulse_frames_left = -1;
                     sample = 0.0;
                     write_time(outstream, seconds_per_frame * frame); // announce beep end
@@ -123,6 +127,7 @@ static void write_callback(struct SoundIoOutStream *outstream, int frame_count_m
 }
 
 static void underflow_callback(struct SoundIoOutStream *outstream) {
+    (void)outstream;
     soundio_panic("underflow\n");
 }
 

--- a/test/overflow.c
+++ b/test/overflow.c
@@ -12,7 +12,27 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+
+#ifndef _MSC_VER
 #include <unistd.h>
+
+__attribute__ ((cold))
+__attribute__ ((noreturn))
+__attribute__ ((format (printf, 1, 2)))
+static void panic(const char *format, ...) {
+#else 
+#include <Windows.h>
+#define sleep(x) Sleep(x * 1000)
+
+__declspec(noreturn) static void panic(const char *format, ...) {
+#endif
+    va_list ap;
+    va_start(ap, format);
+    vfprintf(stderr, format, ap);
+    fprintf(stderr, "\n");
+    va_end(ap);
+    abort();
+}
 
 static enum SoundIoFormat prioritized_formats[] = {
     SoundIoFormatFloat32NE,
@@ -36,17 +56,6 @@ static enum SoundIoFormat prioritized_formats[] = {
     SoundIoFormatInvalid,
 };
 
-__attribute__ ((cold))
-__attribute__ ((noreturn))
-__attribute__ ((format (printf, 1, 2)))
-static void panic(const char *format, ...) {
-    va_list ap;
-    va_start(ap, format);
-    vfprintf(stderr, format, ap);
-    fprintf(stderr, "\n");
-    va_end(ap);
-    abort();
-}
 
 static int usage(char *exe) {
     fprintf(stderr, "Usage: %s [options]\n"

--- a/test/underflow.c
+++ b/test/underflow.c
@@ -12,13 +12,22 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
-#include <unistd.h>
 #include <stdint.h>
 
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
+
+#ifndef _MSC_VER
 __attribute__ ((cold))
 __attribute__ ((noreturn))
 __attribute__ ((format (printf, 1, 2)))
 static void panic(const char *format, ...) {
+#else
+#include <Windows.h>
+#define sleep(x) Sleep(x * 1000)
+__declspec(noreturn) static void panic(const char *format, ...) {
+#endif
     va_list ap;
     va_start(ap, format);
     vfprintf(stderr, format, ap);


### PR DESCRIPTION
!! Not ready for merging yet.

I'd like to put forward a proposal to provide support for MSVC native builds on more modern versions of windows. 

Providing more seamless support for MSVC should greatly improve the adoption story for the library, and make it easier to use from other languages (nim, rust, zig etc..) as it reduces the need for a cross compiling environment. Several issues have pointed this out such as #255 

I Intend to provide a msvc compatible build leveraging cmake as the build generator. I've started some initial work on a PR here. as a proof of concept.

On windows you can now just 

```
mkdir build && cd build; 
cmake ../ && start libsoundio.sln
```
And build through visual studio. (tested so far with vs 2022) No further dependencies are needed to use the WASAPI. It seems there has been some MSVC Support already from looking through the CMakeLists.txt.

Three issues need to be addressed in order to provide this support, and I'd like to hear thoughts.

1. msvc hilariously still doesn't support __typeof__ and its' ilk of functions making an implementation of stdatomic.h not possible.
2. unistd.h is not available on msvc platforms
3. warnings and general build ecosystem stuff need to pass in MSVC builds.

## 1. an implementation of stdatomic.h not possible.
To remedy the lack of stdatomic.h I propose to leverage MSVC compiler intrinsics to implement the functions needed by the library and its' tests. this does result in an change in the `atomics.h` api. all `SOUNDIO_ATOMIC_XXX` functions now need to reference the target type of atomic they are operating on. 

This is similar to the approach used by https://github.com/mintomic/mintomic (and its' replacement; turf) to achieve cross platform atomic implementation in C. 

## 2. unistd.h is not available on msvc platforms

to this end unistd wont be used on the MSVC builds the only thing that was needed was `sleep` this is easily replaced by the `windows.h` 's `Sleep` function.

## 3. Passing all warnings in MSVC

This one sounds like a nice to have, and I'm still working on it. 

But for a lot of warnings especially regarding Windows' static analyzer we may not be able to get all of them. In particular, ones where microsoft reaaly want you to decorate pointers with compiler specific attributes.

Some warnings I'm trying to fix pedantically: 
1. inserting explicit casts where warned about
2. removing shadowed variables
3. (void) to mark unused variables.
4. proper declspec export macros for windows builds

## Continuing on.

Let me know if this is a good direction for the library and I should commit to testing this far more rigorously, or if this should stay in a seperate fork.