### PR TITLE
void debug-only variables to prevent warnings if NDEBUG is defined

### DIFF
--- a/src/os.c
+++ b/src/os.c
@@ -742,6 +742,7 @@ void soundio_os_deinit_mirrored_memory(struct SoundIoOsMirroredMemory *mem) {
 #else
     int err = munmap(mem->address, 2 * mem->capacity);
     assert(!err);
+    (void) err;
 #endif
     mem->address = NULL;
 }

--- a/src/util.c
+++ b/src/util.c
@@ -35,6 +35,7 @@ char *soundio_alloc_sprintf(int *len, const char *format, ...) {
 
     int len2 = vsnprintf(mem, required_size, format, ap2);
     assert(len2 == len1);
+    (void)len2;
 
     va_end(ap2);
     va_end(ap);


### PR DESCRIPTION
fix https://github.com/andrewrk/libsoundio/issues/277