### PR TITLE
Add SoundIoFormatS24PackedLE format for WASAPI

### DIFF
--- a/src/wasapi.c
+++ b/src/wasapi.c
@@ -138,6 +138,7 @@ static enum SoundIoFormat test_formats[] = {
     SoundIoFormatU8,
     SoundIoFormatS16LE,
     SoundIoFormatS24LE,
+    SoundIoFormatS24PackedLE,
     SoundIoFormatS32LE,
     SoundIoFormatFloat32LE,
     SoundIoFormatFloat64LE,
@@ -306,6 +307,9 @@ static enum SoundIoFormat from_wave_format_format(WAVEFORMATEXTENSIBLE *wave_for
         } else if (wave_format->Format.wBitsPerSample == 16) {
             if (is_pcm)
                 return SoundIoFormatS16LE;
+        } else if (wave_format->Format.wBitsPerSample == 24) {
+            if (is_pcm)
+                return SoundIoFormatS24PackedLE;
         } else if (wave_format->Format.wBitsPerSample == 32) {
             if (is_pcm)
                 return SoundIoFormatS32LE;
@@ -403,6 +407,11 @@ static void to_wave_format_format(enum SoundIoFormat format, WAVEFORMATEXTENSIBL
         wave_format->SubFormat = SOUNDIO_KSDATAFORMAT_SUBTYPE_PCM;
         wave_format->Format.wBitsPerSample = 16;
         wave_format->Samples.wValidBitsPerSample = 16;
+        break;
+    case SoundIoFormatS24PackedLE:
+        wave_format->SubFormat = SOUNDIO_KSDATAFORMAT_SUBTYPE_PCM;
+        wave_format->Format.wBitsPerSample = 24;
+        wave_format->Samples.wValidBitsPerSample = 24;
         break;
     case SoundIoFormatS24LE:
         wave_format->SubFormat = SOUNDIO_KSDATAFORMAT_SUBTYPE_PCM;


### PR DESCRIPTION
I add SoundIoFormatS24PackedLE format on wasapi.c for v2 branch.

I'm using a DAC named [UR-12](https://www.steinberg.net/audio-interfaces/ur12/), and I notice this DAC probably only support 24bit packed format in wasapi exclusive mode.

Thus, I add supporting SoundIoFormatS24PackedLE on wasapi.c while referencing issue #94.

After this adding, I verified that example/sio_list_devices.exe and example/sio_sine.exe (modified) run correctly on my environment (WIndows 10 version 22H2).