### PR TITLE
coreaudio: add fallback aliases for < 10.8

### DIFF
--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -11,6 +11,11 @@
 #include <assert.h>
 
 #include "AvailabilityMacros.h"
+#ifndef MAC_OS_X_VERSION_10_8
+#define kAudioObjectPropertyScopeInput kAudioDevicePropertyScopeInput
+#define kAudioObjectPropertyScopeOutput kAudioDevicePropertyScopeOutput
+#define kAudioHardwarePropertyServiceRestarted 'srst'
+#endif
 #ifndef MAC_OS_VERSION_12_0
 #define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
 #endif


### PR DESCRIPTION
Closes: https://github.com/andrewrk/libsoundio/issues/290

Refs:
https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.8.sdk/System/Library/Frameworks/CoreAudio.framework/Versions/A/Headers/AudioHardwareDeprecated.h#L52-L53

https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.8.sdk/System/Library/Frameworks/CoreAudio.framework/Versions/A/Headers/AudioHardware.h#L536-L540
https://github.com/phracker/MacOSX-SDKs/blob/041600eda65c6a668f66cb7d56b7d1da3e8bcc93/MacOSX10.8.sdk/System/Library/Frameworks/CoreAudio.framework/Versions/A/Headers/AudioHardware.h#L561