### PR TITLE
mac: Fix building on macOS 14.

### DIFF
--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -11,7 +11,7 @@
 #include <assert.h>
 
 #include "AvailabilityMacros.h"
-#ifndef MAC_OS_VERSION_12_0
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 #define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
 #endif
 


### PR DESCRIPTION
When I built on macOS 14, the following error occurred. This error is a recurrence of the issue fixed in #280.

```
/Users/harukasan/works/src/github.com/andrewrk/libsoundio/src/coreaudio.c:26:9: error: 'kAudioObjectPropertyElementMaster' is deprecated: first deprecated in macOS 12.0 [-Werror,-Wdeprecated-declarations]
        kAudioObjectPropertyElementMain
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        kAudioObjectPropertyElementMain
/Users/harukasan/works/src/github.com/andrewrk/libsoundio/src/coreaudio.c:16:41: note: expanded from macro 'kAudioObjectPropertyElementMain'
#define kAudioObjectPropertyElementMain kAudioObjectPropertyElementMaster
                                        ^
```

`MAC_OS_VERSION_12_0` is not defined in macOS 14. Therefore, I fixed the version check to use `MAC_OS_X_VERSION_MIN_REQUIRED`.

I only have a macOS 14 environment, so I cannot test on earlier versions.
Please verify that there are no issues in older environments before merging.